### PR TITLE
Refactor LocalStorageProvider

### DIFF
--- a/src/main/java/com/itasocialacademy/oitassist/filemanager/providers/LocalStorageProvider.java
+++ b/src/main/java/com/itasocialacademy/oitassist/filemanager/providers/LocalStorageProvider.java
@@ -15,72 +15,92 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+/**
+ * Implementation of {@link StorageProvider} for local file system storage. This
+ * provider manages files within a configured root directory and returns
+ * OS-independent relative paths for database persistence. This ensures
+ * portability across different environments (Windows, Linux, Docker).
+ */
 @Slf4j
 @Component
 public class LocalStorageProvider implements StorageProvider {
-    private final String rootPath;
+    /**
+     * The absolute, normalized root path where all files are stored.
+     */
+    private final Path root;
 
+    /**
+     * Constructs the provider and pre-calculates the absolute root path.
+     *
+     * @param rootPath the base directory for storage, defaults to "./uploads"
+     */
     public LocalStorageProvider(@Value("${app.storage.local.root:./uploads}") String rootPath) {
-        this.rootPath = rootPath;
+        this.root = Paths.get(rootPath).toAbsolutePath().normalize();
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @return {@link StorageProviderType#LOCAL}
+     */
     @Override
     public StorageProviderType getType() {
         return StorageProviderType.LOCAL;
     }
 
+    /**
+     * Uploads a file to the local file system and returns a relative storage key.
+     * The method performs security checks to prevent path traversal and ensures the
+     * directory structure exists before writing the file.
+     *
+     * @param inputStream the data stream of the file
+     * @param morphedName the unique filename to be used on disk
+     * @param path        the subdirectory path within the storage root
+     * @return a relative, forward-slash separated storage key for database storage
+     * @throws FileUploadException if the path is invalid or an I/O error occurs
+     */
     @Override
     public String upload(InputStream inputStream, String morphedName, String path) {
         try {
-            Path root = Paths.get(rootPath).toAbsolutePath().normalize();
-            Path normalizedDirectory = root.resolve(path).normalize();
-            Path normalizedFile = normalizedDirectory.resolve(morphedName).normalize();
+            Path targetDirectory = root.resolve(path).normalize();
+            Path targetFile = targetDirectory.resolve(morphedName).normalize();
 
-            if (!normalizedDirectory.startsWith(root) || !normalizedFile.startsWith(root)) {
+            if (!targetFile.startsWith(root)) {
                 throw new FileUploadException("Invalid upload path outside configured storage root",
                     new IllegalArgumentException(path));
             }
-            Files.createDirectories(normalizedDirectory);
 
-            // are we okay with the silent overwrite?
-            Files.copy(inputStream, normalizedFile, StandardCopyOption.REPLACE_EXISTING);
+            Files.createDirectories(targetDirectory);
+            Files.copy(inputStream, targetFile, StandardCopyOption.REPLACE_EXISTING);
 
-            log.info("File successfully uploaded to: {}", normalizedFile);
+            log.info("File successfully uploaded to: {}", targetFile);
 
-            return normalizedFile.toString();
+            return root.relativize(targetFile).toString().replace("\\", "/");
         } catch (IOException e) {
             log.error("Failed to upload file {} to path {}", morphedName, path, e);
             throw new FileUploadException("Could not store file locally", e);
         }
     }
 
+    /**
+     * Deletes a file from the local file system using its relative storage key.
+     *
+     * @param storageKey the relative path of the file as stored in the database
+     * @throws InvalidFilePathException if the path is empty or points outside the
+     *                                  storage root
+     * @throws FileDeleteException      if an I/O error occurs during deletion
+     */
     @Override
-    public void deletePhysical(String fileFullPath) {
-        if (fileFullPath == null || fileFullPath.isBlank()) {
-            throw new InvalidFilePathException("Cannot delete local file: blank storage path");
+    public void deletePhysical(String storageKey) {
+        if (storageKey == null || storageKey.isBlank()) {
+            throw new InvalidFilePathException("Cannot delete local file: blank storage key");
         }
 
         try {
-            Path root = Paths.get(rootPath).toAbsolutePath().normalize();
-            Path inputPath = Paths.get(fileFullPath);
-            Path target;
-
-            if (inputPath.isAbsolute()) {
-                target = inputPath.normalize();
-            } else {
-                target = root.resolve(fileFullPath).normalize();
-                if (!Files.exists(target) && fileFullPath.startsWith(root.getFileName().toString())) {
-                    Path strippedPath = inputPath.subpath(1, inputPath.getNameCount());
-                    Path candidateTarget = root.resolve(strippedPath).normalize();
-                    if (Files.exists(candidateTarget)) {
-                        target = candidateTarget;
-                    }
-                }
-            }
+            Path target = root.resolve(storageKey).normalize();
 
             if (!target.startsWith(root)) {
-                throw new InvalidFilePathException("Invalid delete path outside configured storage root: "
-                    + fileFullPath);
+                throw new InvalidFilePathException("Access denied: path is outside storage root: " + storageKey);
             }
 
             boolean deleted = Files.deleteIfExists(target);
@@ -88,11 +108,11 @@ public class LocalStorageProvider implements StorageProvider {
             if (deleted) {
                 log.info("File deleted successfully: {}", target);
             } else {
-                log.warn("File not found at: {}", target.toAbsolutePath());
+                log.warn("File not found for deletion at: {}", target);
             }
         } catch (IOException e) {
-            log.error("Could not delete physical file at: {}", fileFullPath, e);
-            throw new FileDeleteException("Could not delete physical file: " + fileFullPath, e);
+            log.error("Could not delete physical file at: {}", storageKey, e);
+            throw new FileDeleteException("Could not delete physical file: " + storageKey, e);
         }
     }
 }

--- a/src/main/java/com/itasocialacademy/oitassist/filemanager/providers/interfaces/StorageProvider.java
+++ b/src/main/java/com/itasocialacademy/oitassist/filemanager/providers/interfaces/StorageProvider.java
@@ -28,7 +28,7 @@ public interface StorageProvider {
     /**
      * Physically deletes a file.
      *
-     * @param filePath full file path including filename.
+     * @param filePath relative path including filename.
      */
     void deletePhysical(String filePath);
 }

--- a/src/test/java/com/itasocialacademy/oitassist/filemanager/controller/FileControllerTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/filemanager/controller/FileControllerTest.java
@@ -1,7 +1,7 @@
 package com.itasocialacademy.oitassist.filemanager.controller;
 
+import com.itasocialacademy.oitassist.filemanager.exceptions.FileAssetNotFoundException;
 import com.itasocialacademy.oitassist.filemanager.service.interfaces.FileService;
-import java.io.FileNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -38,10 +38,10 @@ class FileControllerTest {
 
     @Test
     void deleteSoft_ShouldThrowException_WhenServiceThrows() {
-        doThrow(new FileNotFoundException("File not found"))
+        doThrow(new FileAssetNotFoundException("File not found"))
             .when(fileService).deleteSoft(FILE_ID);
 
-        assertThrows(FileNotFoundException.class, () -> fileController.deleteSoft(FILE_ID));
+        assertThrows(FileAssetNotFoundException.class, () -> fileController.deleteSoft(FILE_ID));
 
         verify(fileService, times(1)).deleteSoft(FILE_ID);
     }
@@ -60,10 +60,10 @@ class FileControllerTest {
 
     @Test
     void deleteHard_ShouldThrowException_WhenServiceThrows() {
-        doThrow(new FileNotFoundException("File not found"))
+        doThrow(new FileAssetNotFoundException("File not found"))
             .when(fileService).deleteHard(FILE_ID);
 
-        assertThrows(FileNotFoundException.class, () -> fileController.deleteHard(FILE_ID));
+        assertThrows(FileAssetNotFoundException.class, () -> fileController.deleteHard(FILE_ID));
         verify(fileService, times(1)).deleteHard(FILE_ID);
     }
 }

--- a/src/test/java/com/itasocialacademy/oitassist/filemanager/providers/LocalStorageProviderTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/filemanager/providers/LocalStorageProviderTest.java
@@ -34,6 +34,15 @@ class LocalStorageProviderTest {
     }
 
     //
+    // getType() SECTION TESTS
+    //
+
+    @Test
+    void getType_ShouldReturnLocal() {
+        assertThat(localStorageProvider.getType()).isEqualTo(StorageProviderType.LOCAL);
+    }
+
+    //
     // supports() SECTION TESTS
     //
 
@@ -52,16 +61,15 @@ class LocalStorageProviderTest {
     //
 
     @Test
-    void deletePhysical_ShouldHandleRedundantRootPrefix() throws IOException {
-        String fileName = "sample.pdf";
-        Path file = tempDir.resolve(fileName);
+    void deletePhysical_ShouldDeleteFileUsingRelativeStorageKey() throws IOException {
+        Path subDir = tempDir.resolve("news");
+        Files.createDirectories(subDir);
+        Path file = subDir.resolve("article.jpg");
         Files.createFile(file);
 
-        String redundantPath = tempDir.getFileName().toString() + "/" + fileName;
+        localStorageProvider.deletePhysical("news/article.jpg");
 
-        localStorageProvider.deletePhysical(redundantPath);
-
-        assertFalse(Files.exists(file), "File should be deleted even with redundant root prefix");
+        assertFalse(Files.exists(file), "File should be deleted using relative storage key");
     }
 
     @Test
@@ -78,30 +86,29 @@ class LocalStorageProviderTest {
 
     @Test
     void deletePhysical_ShouldThrowException_WhenPathIsOutsideRoot() {
-        String maliciousPath = "../secret.txt";
+        String maliciousKey = "../secret.txt";
 
-        assertThatThrownBy(() -> localStorageProvider.deletePhysical(maliciousPath))
+        assertThatThrownBy(() -> localStorageProvider.deletePhysical(maliciousKey))
             .isInstanceOf(InvalidFilePathException.class)
-            .hasMessageContaining("Invalid delete path outside configured storage root");
+            .hasMessageContaining("Access denied: path is outside storage root");
     }
 
     @Test
-    void deletePhysical_ShouldThrowException_WhenPathIsBlank() {
+    void deletePhysical_ShouldThrowException_WhenKeyIsBlank() {
         assertThrows(InvalidFilePathException.class, () -> localStorageProvider.deletePhysical("   "));
         assertThrows(InvalidFilePathException.class, () -> localStorageProvider.deletePhysical(null));
     }
 
     @Test
     void deletePhysical_ShouldThrowFileDeleteException_WhenFileSystemFails() throws IOException {
-        Path file = tempDir.resolve("locked.txt");
+        Path file = tempDir.resolve("protected.txt");
         Files.createFile(file);
-        String filePath = file.toString();
 
         try (MockedStatic<Files> mockedFiles = mockStatic(Files.class)) {
             mockedFiles.when(() -> Files.deleteIfExists(any(Path.class)))
-                .thenThrow(new IOException("Permission denied"));
+                .thenThrow(new IOException("Lock error"));
 
-            assertThatThrownBy(() -> localStorageProvider.deletePhysical(filePath))
+            assertThatThrownBy(() -> localStorageProvider.deletePhysical("protected.txt"))
                 .isInstanceOf(FileDeleteException.class)
                 .hasMessageContaining("Could not delete physical file");
         }
@@ -122,10 +129,8 @@ class LocalStorageProviderTest {
 
     @Test
     void deletePhysical_ShouldNotThrowException_WhenFileDoesNotExist() {
-        String nonExistentPath = tempDir.resolve("non-existent.txt").toString();
-
-        assertDoesNotThrow(() -> localStorageProvider.deletePhysical(nonExistentPath),
-            "Should handle non-existent files gracefully without throwing exceptions");
+        assertDoesNotThrow(() -> localStorageProvider.deletePhysical("non-existent/file.txt"),
+            "Should handle non-existent files gracefully");
     }
 
     //
@@ -133,17 +138,19 @@ class LocalStorageProviderTest {
     //
 
     @Test
-    void upload_ShouldSaveFileAndReturnPath_WhenInputIsValid() throws IOException {
+    void upload_ShouldSaveFileAndReturnRelativePathWithForwardSlashes() throws IOException {
         String fileName = "test-image.png";
-        String subPath = "uploads/avatars";
+        String subPath = "uploads/avatars"; // Using forward slashes in input
         String content = "fake-image-content";
         InputStream inputStream = new ByteArrayInputStream(content.getBytes());
 
-        String resultPath = localStorageProvider.upload(inputStream, fileName, subPath);
+        String resultKey = localStorageProvider.upload(inputStream, fileName, subPath);
 
-        Path expectedFile = tempDir.resolve(subPath).resolve(fileName);
+        // Assert: The returned key must be relative and use forward slashes
+        assertThat(resultKey).isEqualTo("uploads/avatars/test-image.png");
 
-        assertThat(resultPath).isEqualTo(expectedFile.toString());
+        // Verify physical file existence
+        Path expectedFile = tempDir.resolve("uploads/avatars").resolve(fileName);
         assertThat(Files.exists(expectedFile)).isTrue();
         assertThat(Files.readString(expectedFile)).isEqualTo(content);
     }
@@ -152,9 +159,9 @@ class LocalStorageProviderTest {
     void upload_ShouldThrowException_WhenPathAttemptsTraversal() {
         InputStream content = new ByteArrayInputStream("data".getBytes());
 
-        assertThatThrownBy(() -> localStorageProvider.upload(content, "hack.exe", "../../../outside"))
+        assertThatThrownBy(() -> localStorageProvider.upload(content, "hack.exe", "../../etc"))
             .isInstanceOf(FileUploadException.class)
-            .hasMessageContaining("Invalid upload path");
+            .hasMessageContaining("Invalid upload path outside configured storage root");
     }
 
     @Test

--- a/src/test/java/com/itasocialacademy/oitassist/filemanager/service/FileServiceImplTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/filemanager/service/FileServiceImplTest.java
@@ -7,7 +7,8 @@ import com.itasocialacademy.oitassist.filemanager.dao.repository.FileRepository;
 import com.itasocialacademy.oitassist.filemanager.exceptions.FileAssetNotFoundException;
 import com.itasocialacademy.oitassist.filemanager.exceptions.UnsupportedStorageException;
 import com.itasocialacademy.oitassist.filemanager.providers.LocalStorageProvider;
-import java.util.List;
+import com.itasocialacademy.oitassist.filemanager.providers.interfaces.StorageProvider;
+import com.itasocialacademy.oitassist.filemanager.providers.resolver.StorageProviderResolver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,7 +18,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -27,6 +27,12 @@ class FileServiceImplTest {
 
     @Mock
     private FileRepository fileRepository;
+
+    @Mock
+    private StorageProviderResolver providerResolver;
+
+    @Mock
+    private StorageProvider storageProvider;
 
     @InjectMocks
     private FileServiceImpl fileService;
@@ -40,8 +46,6 @@ class FileServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        ReflectionTestUtils.setField(fileService, "providers", List.of(localStorageProvider));
-
         fileId = 1L;
         existingFile = new FileAsset();
         existingFile.setId(fileId);
@@ -60,16 +64,14 @@ class FileServiceImplTest {
     void deleteSoft_ShouldUpdateStatusAndTimestamp_WhenFileExists() {
         when(fileRepository.findById(fileId)).thenReturn(Optional.of(existingFile));
 
-        ArgumentCaptor<FileAsset> fileCaptor = ArgumentCaptor.forClass(FileAsset.class);
-
         fileService.deleteSoft(fileId);
 
+        ArgumentCaptor<FileAsset> fileCaptor = ArgumentCaptor.forClass(FileAsset.class);
         verify(fileRepository).save(fileCaptor.capture());
-        FileAsset savedFile = fileCaptor.getValue();
 
+        FileAsset savedFile = fileCaptor.getValue();
         assertEquals(FileStatus.SOFT_DELETED, savedFile.getStatus());
-        assertNotNull(savedFile.getDeletedAt(), "DeletedAt timestamp should be populated");
-        assertEquals(fileId, savedFile.getId());
+        assertNotNull(savedFile.getDeletedAt());
     }
 
     @Test
@@ -77,7 +79,6 @@ class FileServiceImplTest {
         when(fileRepository.findById(nonExistentId)).thenReturn(Optional.empty());
 
         assertThrows(FileAssetNotFoundException.class, () -> fileService.deleteSoft(nonExistentId));
-
         verify(fileRepository, never()).save(any());
     }
 
@@ -89,20 +90,46 @@ class FileServiceImplTest {
         existingFile.setStorageKey(testPath);
 
         when(fileRepository.findById(fileId)).thenReturn(Optional.of(existingFile));
-        when(localStorageProvider.supports(StorageProviderType.LOCAL)).thenReturn(true);
+        when(providerResolver.resolve(StorageProviderType.LOCAL)).thenReturn(storageProvider);
 
         fileService.deleteHard(fileId);
-        verify(localStorageProvider).deletePhysical(testPath);
+
+        verify(storageProvider).deletePhysical(testPath);
 
         ArgumentCaptor<FileAsset> captor = ArgumentCaptor.forClass(FileAsset.class);
         verify(fileRepository).save(captor.capture());
 
         FileAsset result = captor.getValue();
         assertEquals(FileStatus.HARD_DELETED, result.getStatus());
-
         assertEquals("", result.getStorageKey());
+    }
 
-        verify(localStorageProvider, times(1)).deletePhysical(testPath);
+    @Test
+    void deleteHard_ShouldThrowUnsupportedStorageException_WhenResolverFails() {
+        when(fileRepository.findById(fileId)).thenReturn(Optional.of(existingFile));
+        // Simulate resolver throwing exception if provider not found
+        when(providerResolver.resolve(any())).thenThrow(UnsupportedStorageException.class);
+
+        assertThrows(UnsupportedStorageException.class, () -> fileService.deleteHard(fileId));
+
+        verify(fileRepository, never()).save(any());
+    }
+
+    @Test
+    void deleteHard_ShouldSetStatusToFailed_WhenPhysicalDeletionThrowsException() {
+        existingFile.setStorageKey("path/to/fail");
+        when(fileRepository.findById(fileId)).thenReturn(Optional.of(existingFile));
+        when(providerResolver.resolve(any())).thenReturn(storageProvider);
+
+        // Mock a failure during physical deletion
+        doThrow(new RuntimeException("IO Error")).when(storageProvider).deletePhysical(anyString());
+
+        fileService.deleteHard(fileId);
+
+        ArgumentCaptor<FileAsset> captor = ArgumentCaptor.forClass(FileAsset.class);
+        verify(fileRepository).save(captor.capture());
+
+        assertEquals(FileStatus.FAILED, captor.getValue().getStatus());
     }
 
     @Test
@@ -113,31 +140,5 @@ class FileServiceImplTest {
 
         verify(localStorageProvider, never()).deletePhysical(any());
         verify(fileRepository, never()).save(any());
-    }
-
-    @Test
-    void deleteHard_ShouldThrowUnsupportedStorageException_WhenNoProviderMatches() {
-        existingFile.setStorageProvider(null);
-        when(fileRepository.findById(fileId)).thenReturn(Optional.of(existingFile));
-        when(localStorageProvider.supports(any())).thenReturn(false);
-
-        assertThrows(UnsupportedStorageException.class, () -> fileService.deleteHard(fileId));
-
-        verify(localStorageProvider, never()).deletePhysical(any());
-        verify(fileRepository, never()).save(any());
-    }
-
-    @Test
-    void deleteHard_ShouldSucceed_EvenIfPhysicalFileIsAlreadyMissing() {
-        String path = "/uploads/test.txt";
-        existingFile.setStorageKey(path);
-
-        when(fileRepository.findById(fileId)).thenReturn(Optional.of(existingFile));
-        when(localStorageProvider.supports(any())).thenReturn(true);
-
-        assertDoesNotThrow(() -> fileService.deleteHard(fileId));
-
-        verify(localStorageProvider).deletePhysical(path);
-        verify(fileRepository).save(any());
     }
 }

--- a/src/test/java/com/itasocialacademy/oitassist/filemanager/service/FileServiceImplTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/filemanager/service/FileServiceImplTest.java
@@ -6,7 +6,6 @@ import com.itasocialacademy.oitassist.filemanager.dao.enums.FileStatus;
 import com.itasocialacademy.oitassist.filemanager.dao.repository.FileRepository;
 import com.itasocialacademy.oitassist.filemanager.exceptions.FileAssetNotFoundException;
 import com.itasocialacademy.oitassist.filemanager.exceptions.UnsupportedStorageException;
-import com.itasocialacademy.oitassist.filemanager.providers.LocalStorageProvider;
 import com.itasocialacademy.oitassist.filemanager.providers.interfaces.StorageProvider;
 import com.itasocialacademy.oitassist.filemanager.providers.resolver.StorageProviderResolver;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,9 +35,6 @@ class FileServiceImplTest {
 
     @InjectMocks
     private FileServiceImpl fileService;
-
-    @Mock
-    private LocalStorageProvider localStorageProvider;
 
     private Long fileId;
     private Long nonExistentId;
@@ -138,7 +134,7 @@ class FileServiceImplTest {
 
         assertThrows(FileAssetNotFoundException.class, () -> fileService.deleteHard(nonExistentId));
 
-        verify(localStorageProvider, never()).deletePhysical(any());
+        verifyNoInteractions(providerResolver, storageProvider);
         verify(fileRepository, never()).save(any());
     }
 }


### PR DESCRIPTION
* **Relative Path Storage:** The `upload` method now uses `root.relativize(targetFile)`. This means the database will now hold strings like `news/filename.pdf` instead of the full Windows path.
* **OS Independence:** Added `.replace("\\", "/")` to the return value. This ensures that even if we develop on Windows, the database uses standard web-friendly forward slashes.
* **Centralized Root:** The `root` is converted to an absolute `Path` once in the constructor. This removes the repetitive `Paths.get(rootPath)...` boilerplate in every method.
* **Simplified Deletion:** Since we are now using a consistent `storageKey` (the relative path), the complex logic to "strip the root name" in `deletePhysical` is no longer necessary. We simply `resolve` the key against the `root`.
* **Path Traversal Protection:** The `startsWith(root)` check is retained as a critical security measure to ensure a malicious user can't pass a path like `../../etc/passwd` to delete or overwrite system files.

Closes #162 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stronger path validation to prevent access outside the configured storage root.
  * Uploads now return consistent, root-relative storage keys using forward-slash separators.
  * Delete operations now accept relative storage keys and are constrained to the storage root.

* **Tests**
  * Updated and added unit tests to cover storage-key behavior, improved error messages, resolver-based deletion flows, and enhanced error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->