### PR TITLE
Add unit tests for file upload flow, validation module, and storage provider resolver

### DIFF
--- a/src/main/java/com/itasocialacademy/oitassist/core/web/GlobalExceptionHandler.java
+++ b/src/main/java/com/itasocialacademy/oitassist/core/web/GlobalExceptionHandler.java
@@ -22,9 +22,11 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
 /**
  * Centralized exception handler for the entire application.
+ *
  * <p>
  * This {@link ControllerAdvice} intercepts exceptions thrown from controllers
  * or service layers and converts them into standardized {@link ErrorResponse}
@@ -56,6 +58,7 @@ import java.util.stream.Collectors;
  * </ul>
  *
  * <h2>Trace ID</h2>
+ *
  * <p>
  * Supports tracing via:
  * <ul>
@@ -202,5 +205,26 @@ public class GlobalExceptionHandler {
                 "Access denied",
                 status.value(),
                 null));
+    }
+
+    /**
+     * Handles {@link MissingServletRequestPartException} by generating an
+     * appropriate error response. This exception is thrown when a required part of
+     * a multipart request is missing.
+     *
+     * @param ex      the exception object containing details of the missing request
+     *                part
+     * @param request the HTTP request that triggered the exception
+     * @return a {@link ResponseEntity} containing an {@link ErrorResponse} with
+     *         error details, including the specific request part that was missing
+     */
+    @ExceptionHandler(MissingServletRequestPartException.class)
+    public ResponseEntity<ErrorResponse> handleMissingServletRequestPart(
+        MissingServletRequestPartException ex, HttpServletRequest request) {
+        log.warn("Missing request part: traceId={}, part={}", MDC.get("traceId"), ex.getRequestPartName());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(buildResponse(request, ErrorCode.COMMON_VALIDATION_FAILED,
+                "Required request part '" + ex.getRequestPartName() + "' is not present",
+                HttpStatus.BAD_REQUEST.value(), null));
     }
 }

--- a/src/test/java/com/itasocialacademy/oitassist/ControllerUnitTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/ControllerUnitTest.java
@@ -10,14 +10,14 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import tools.jackson.databind.ObjectMapper;
 
 @ExtendWith(MockitoExtension.class)
-public abstract class ControllerUnitTest {
+public abstract class ControllerUnitTest<T> {
     public MockMvc mockMvc;
 
     protected final ObjectMapper objectMapper = new ObjectMapper();
 
     private final AppExceptionHttpStatusMapper mapper = new AppExceptionHttpStatusMapper();
 
-    protected abstract Object getController();
+    protected abstract T getController();
 
     @BeforeEach
     public void setup() {

--- a/src/test/java/com/itasocialacademy/oitassist/filemanager/controller/FileControllerTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/filemanager/controller/FileControllerTest.java
@@ -1,22 +1,27 @@
 package com.itasocialacademy.oitassist.filemanager.controller;
 
-import com.itasocialacademy.oitassist.filemanager.exceptions.FileAssetNotFoundException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.itasocialacademy.oitassist.ControllerUnitTest;
+import com.itasocialacademy.oitassist.filemanager.dao.enums.RelatedEntityType;
+import com.itasocialacademy.oitassist.filemanager.dto.request.FileUploadRequestDto;
+import com.itasocialacademy.oitassist.filemanager.dto.response.FileResponseDto;
+import com.itasocialacademy.oitassist.filemanager.exceptions.FileUploadException;
 import com.itasocialacademy.oitassist.filemanager.service.interfaces.FileService;
+import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
-
-//add MockMvc to perform requests and verify @PreAuthorize with @WithMockUser
-
-@ExtendWith(MockitoExtension.class)
-class FileControllerTest {
+class FileControllerTest extends ControllerUnitTest<FileController> {
 
     @Mock
     private FileService fileService;
@@ -24,46 +29,111 @@ class FileControllerTest {
     @InjectMocks
     private FileController fileController;
 
-    private static final Long FILE_ID = 0L;
+    @Override
+    protected FileController getController() {
+        return fileController;
+    }
 
-    // --- Soft Delete Tests ---
+    private MockMultipartFile singleFilePart() {
+        return new MockMultipartFile("files", "photo.jpg", MediaType.IMAGE_JPEG_VALUE, "image-bytes".getBytes());
+    }
+
+    private MockMultipartFile metadataPart(FileUploadRequestDto dto) throws Exception {
+        return new MockMultipartFile("metadata", "", MediaType.APPLICATION_JSON_VALUE,
+            objectMapper.writeValueAsBytes(dto));
+    }
+
+    // --- Upload Tests ---
 
     @Test
-    void deleteSoft_ShouldReturnNoContent_WhenSuccessful() {
-        doNothing().when(fileService).deleteSoft(FILE_ID);
-        ResponseEntity<Void> response = fileController.deleteSoft(FILE_ID);
-        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
-        verify(fileService, times(1)).deleteSoft(FILE_ID);
+    void upload_ShouldReturnCreatedWithBody_WhenFilesUploadedSuccessfully() throws Exception {
+        FileUploadRequestDto requestDto = FileUploadRequestDto.builder()
+            .relatedEntityType(RelatedEntityType.NEWS)
+            .relatedEntityId(10L)
+            .build();
+        List<FileResponseDto> serviceResponse = List.of(
+            FileResponseDto.builder()
+                .id(1L)
+                .storageKey("uploads/photo.jpg")
+                .mimeType(MediaType.IMAGE_JPEG_VALUE)
+                .size(1024L)
+                .build());
+
+        when(fileService.upload(any(), any(), any())).thenReturn(serviceResponse);
+
+        mockMvc.perform(multipart("/api/v1/files")
+            .file(singleFilePart())
+            .file(metadataPart(requestDto)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$[0].id").value(1))
+            .andExpect(jsonPath("$[0].storageKey").value("uploads/photo.jpg"))
+            .andExpect(jsonPath("$[0].mimeType").value(MediaType.IMAGE_JPEG_VALUE))
+            .andExpect(jsonPath("$[0].size").value(1024));
     }
 
     @Test
-    void deleteSoft_ShouldThrowException_WhenServiceThrows() {
-        doThrow(new FileAssetNotFoundException("File not found"))
-            .when(fileService).deleteSoft(FILE_ID);
+    void upload_ShouldDelegateToServiceWithNullUserId_WhenFilesAndMetadataAreValid() throws Exception {
+        // standaloneSetup does not process @AuthenticationPrincipal,
+        // so currentUserId is always null in unit test scope.
+        FileUploadRequestDto requestDto = FileUploadRequestDto.builder()
+            .relatedEntityType(RelatedEntityType.TASK)
+            .relatedEntityId(5L)
+            .build();
 
-        assertThrows(FileAssetNotFoundException.class, () -> fileController.deleteSoft(FILE_ID));
+        when(fileService.upload(any(), any(), eq(null))).thenReturn(List.of());
 
-        verify(fileService, times(1)).deleteSoft(FILE_ID);
-    }
+        mockMvc.perform(multipart("/api/v1/files")
+            .file(singleFilePart())
+            .file(metadataPart(requestDto)))
+            .andExpect(status().isCreated());
 
-    // --- Hard Delete Tests ---
-
-    @Test
-    void deleteHard_ShouldReturnNoContent_WhenSuccessful() {
-        doNothing().when(fileService).deleteHard(FILE_ID);
-
-        ResponseEntity<Void> response = fileController.deleteHard(FILE_ID);
-
-        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
-        verify(fileService, times(1)).deleteHard(FILE_ID);
+        verify(fileService).upload(any(), any(), eq(null));
     }
 
     @Test
-    void deleteHard_ShouldThrowException_WhenServiceThrows() {
-        doThrow(new FileAssetNotFoundException("File not found"))
-            .when(fileService).deleteHard(FILE_ID);
+    void upload_ShouldReturnBadRequest_WhenRelatedEntityTypeIsMissing() throws Exception {
+        FileUploadRequestDto requestDto = FileUploadRequestDto.builder()
+            .relatedEntityId(10L)
+            .build();
 
-        assertThrows(FileAssetNotFoundException.class, () -> fileController.deleteHard(FILE_ID));
-        verify(fileService, times(1)).deleteHard(FILE_ID);
+        mockMvc.perform(multipart("/api/v1/files")
+            .file(singleFilePart())
+            .file(metadataPart(requestDto)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void upload_ShouldReturnBadRequest_WhenMetadataPartIsMissing() throws Exception {
+        mockMvc.perform(multipart("/api/v1/files")
+            .file(singleFilePart()))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void upload_ShouldReturnBadRequest_WhenFilesPartIsMissing() throws Exception {
+        FileUploadRequestDto requestDto = FileUploadRequestDto.builder()
+            .relatedEntityType(RelatedEntityType.NEWS)
+            .relatedEntityId(10L)
+            .build();
+
+        mockMvc.perform(multipart("/api/v1/files")
+            .file(metadataPart(requestDto)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void upload_ShouldReturnInternalServerError_WhenServiceThrowsFileUploadException() throws Exception {
+        FileUploadRequestDto requestDto = FileUploadRequestDto.builder()
+            .relatedEntityType(RelatedEntityType.NEWS)
+            .relatedEntityId(10L)
+            .build();
+
+        when(fileService.upload(any(), any(), any()))
+            .thenThrow(new FileUploadException("photo.jpg", new RuntimeException("I/O error")));
+
+        mockMvc.perform(multipart("/api/v1/files")
+            .file(singleFilePart())
+            .file(metadataPart(requestDto)))
+            .andExpect(status().isInternalServerError());
     }
 }

--- a/src/test/java/com/itasocialacademy/oitassist/filemanager/providers/resolver/StorageProviderResolverTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/filemanager/providers/resolver/StorageProviderResolverTest.java
@@ -1,0 +1,88 @@
+package com.itasocialacademy.oitassist.filemanager.providers.resolver;
+
+import com.itasocialacademy.oitassist.core.enums.ErrorCode;
+import com.itasocialacademy.oitassist.filemanager.dao.enums.StorageProviderType;
+import com.itasocialacademy.oitassist.filemanager.exceptions.UnsupportedStorageException;
+import com.itasocialacademy.oitassist.filemanager.providers.interfaces.StorageProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StorageProviderResolverTest {
+
+    @Mock
+    private StorageProvider localProvider;
+
+    @Mock
+    private StorageProvider sharepointProvider;
+
+    @Test
+    void resolve_ShouldReturnMatchingProvider_WhenProviderSupportsType() {
+        when(localProvider.supports(StorageProviderType.LOCAL)).thenReturn(true);
+        StorageProviderResolver resolver = new StorageProviderResolver(List.of(localProvider));
+
+        StorageProvider result = resolver.resolve(StorageProviderType.LOCAL);
+
+        assertSame(localProvider, result);
+    }
+
+    @Test
+    void resolve_ShouldReturnCorrectProvider_WhenMultipleProvidersExist() {
+        when(localProvider.supports(StorageProviderType.SHAREPOINT)).thenReturn(false);
+        when(sharepointProvider.supports(StorageProviderType.SHAREPOINT)).thenReturn(true);
+        StorageProviderResolver resolver = new StorageProviderResolver(
+            List.of(localProvider, sharepointProvider));
+
+        StorageProvider result = resolver.resolve(StorageProviderType.SHAREPOINT);
+
+        assertSame(sharepointProvider, result);
+    }
+
+    @Test
+    void resolve_ShouldThrowUnsupportedStorageException_WhenNoProviderSupportsType() {
+        when(localProvider.supports(StorageProviderType.SHAREPOINT)).thenReturn(false);
+        StorageProviderResolver resolver = new StorageProviderResolver(List.of(localProvider));
+
+        UnsupportedStorageException exception = assertThrows(
+            UnsupportedStorageException.class,
+            () -> resolver.resolve(StorageProviderType.SHAREPOINT));
+
+        assertAll(
+            () -> assertTrue(exception.getMessage().contains("SHAREPOINT")),
+            () -> assertEquals(ErrorCode.PROVIDER_NOT_SUPPORTED, exception.getErrorCode()));
+    }
+
+    @Test
+    void resolveDefault_ShouldReturnProvider_WhenDefaultProviderIsConfigured() {
+        when(localProvider.supports(StorageProviderType.LOCAL)).thenReturn(true);
+        StorageProviderResolver resolver = new StorageProviderResolver(List.of(localProvider));
+        ReflectionTestUtils.setField(resolver, "defaultProvider", StorageProviderType.LOCAL);
+
+        StorageProvider result = resolver.resolveDefault();
+
+        assertSame(localProvider, result);
+    }
+
+    @Test
+    void resolveDefault_ShouldThrowUnsupportedStorageException_WhenDefaultProviderHasNoMatchingProvider() {
+        when(localProvider.supports(StorageProviderType.SHAREPOINT)).thenReturn(false);
+        StorageProviderResolver resolver = new StorageProviderResolver(List.of(localProvider));
+        ReflectionTestUtils.setField(resolver, "defaultProvider", StorageProviderType.SHAREPOINT);
+
+        assertThrows(
+            UnsupportedStorageException.class,
+            resolver::resolveDefault);
+    }
+}

--- a/src/test/java/com/itasocialacademy/oitassist/filemanager/service/FileServiceImplTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/filemanager/service/FileServiceImplTest.java
@@ -1,13 +1,22 @@
 package com.itasocialacademy.oitassist.filemanager.service;
 
+import com.itasocialacademy.oitassist.core.exceptions.ValidationException;
+import com.itasocialacademy.oitassist.filemanager.dao.enums.RelatedEntityType;
 import com.itasocialacademy.oitassist.filemanager.dao.enums.StorageProviderType;
 import com.itasocialacademy.oitassist.filemanager.dao.model.FileAsset;
 import com.itasocialacademy.oitassist.filemanager.dao.enums.FileStatus;
 import com.itasocialacademy.oitassist.filemanager.dao.repository.FileRepository;
+import com.itasocialacademy.oitassist.filemanager.dto.request.FileUploadRequestDto;
+import com.itasocialacademy.oitassist.filemanager.dto.response.FileResponseDto;
 import com.itasocialacademy.oitassist.filemanager.exceptions.FileAssetNotFoundException;
+import com.itasocialacademy.oitassist.filemanager.exceptions.FileUploadException;
 import com.itasocialacademy.oitassist.filemanager.exceptions.UnsupportedStorageException;
+import com.itasocialacademy.oitassist.filemanager.mapper.FileMapper;
 import com.itasocialacademy.oitassist.filemanager.providers.interfaces.StorageProvider;
 import com.itasocialacademy.oitassist.filemanager.providers.resolver.StorageProviderResolver;
+import com.itasocialacademy.oitassist.filemanager.validation.FileValidationStrategyResolver;
+import com.itasocialacademy.oitassist.filemanager.validation.interfaces.FileValidationStrategy;
+import com.itasocialacademy.oitassist.filemanager.validation.model.ValidationResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,7 +24,10 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -33,16 +45,27 @@ class FileServiceImplTest {
     @Mock
     private StorageProvider storageProvider;
 
+    @Mock
+    private FileValidationStrategyResolver validationStrategyResolver;
+
+    @Mock
+    private FileValidationStrategy validationStrategy;
+
+    @Mock
+    private FileMapper fileMapper;
+
     @InjectMocks
     private FileServiceImpl fileService;
 
     private Long fileId;
     private Long nonExistentId;
+    private Long userId;
     private FileAsset existingFile;
 
     @BeforeEach
     void setUp() {
         fileId = 1L;
+        userId = 42L;
         existingFile = new FileAsset();
         existingFile.setId(fileId);
         existingFile.setStatus(FileStatus.ATTACHED);
@@ -53,6 +76,181 @@ class FileServiceImplTest {
     }
 
     // --- Upload Tests ---
+
+    @Test
+    void upload_ShouldReturnMappedDtos_WhenFilesAreValid() {
+        MultipartFile file = new MockMultipartFile("file", "photo.jpg", "image/jpeg", new byte[512]);
+        FileUploadRequestDto request = uploadRequest(RelatedEntityType.NEWS, 1L);
+        FileAsset savedAsset = new FileAsset();
+        FileResponseDto expectedDto = FileResponseDto.builder().id(10L).build();
+
+        when(validationStrategyResolver.resolve(RelatedEntityType.NEWS)).thenReturn(validationStrategy);
+        when(validationStrategy.validate(any(), any())).thenReturn(ValidationResult.ok());
+        when(providerResolver.resolveDefault()).thenReturn(storageProvider);
+        when(storageProvider.upload(any(), anyString(), anyString())).thenReturn("news/stored.jpg");
+        when(storageProvider.getType()).thenReturn(StorageProviderType.LOCAL);
+        when(fileRepository.save(any())).thenReturn(savedAsset);
+        when(fileMapper.toDto(savedAsset)).thenReturn(expectedDto);
+
+        List<FileResponseDto> result = fileService.upload(List.of(file), request, userId);
+
+        assertEquals(List.of(expectedDto), result);
+        verify(validationStrategyResolver).resolve(RelatedEntityType.NEWS);
+        verify(providerResolver).resolveDefault();
+        verify(fileRepository).save(any());
+        verify(fileMapper).toDto(savedAsset);
+    }
+
+    @Test
+    void upload_ShouldSaveFileAssetWithCorrectMetadata_WhenUploading() {
+        MultipartFile file = new MockMultipartFile("file", "photo.jpg", "image/jpeg", new byte[512]);
+        FileUploadRequestDto request = uploadRequest(RelatedEntityType.NEWS, 5L);
+        ArgumentCaptor<FileAsset> captor = ArgumentCaptor.forClass(FileAsset.class);
+
+        when(validationStrategyResolver.resolve(any())).thenReturn(validationStrategy);
+        when(validationStrategy.validate(any(), any())).thenReturn(ValidationResult.ok());
+        when(providerResolver.resolveDefault()).thenReturn(storageProvider);
+        when(storageProvider.upload(any(), anyString(), anyString())).thenReturn("news/stored.jpg");
+        when(storageProvider.getType()).thenReturn(StorageProviderType.LOCAL);
+        when(fileRepository.save(any())).thenReturn(new FileAsset());
+        when(fileMapper.toDto(any())).thenReturn(new FileResponseDto());
+
+        fileService.upload(List.of(file), request, userId);
+
+        verify(fileRepository).save(captor.capture());
+        FileAsset saved = captor.getValue();
+        assertAll(
+            () -> assertEquals("photo.jpg", saved.getOriginalFilename()),
+            () -> assertTrue(saved.getStoredFilename().endsWith(".jpg")),
+            () -> assertEquals("news/stored.jpg", saved.getStorageKey()),
+            () -> assertEquals(StorageProviderType.LOCAL, saved.getStorageProvider()),
+            () -> assertEquals(RelatedEntityType.NEWS, saved.getRelatedEntityType()),
+            () -> assertEquals(5L, saved.getRelatedEntityId()),
+            () -> assertEquals(userId, saved.getUserId()),
+            () -> assertEquals("image/jpeg", saved.getMimeType()),
+            () -> assertEquals(512L, saved.getSize()));
+    }
+
+    @Test
+    void upload_ShouldPassRelatedEntityTypeNameAsRelativePath_WhenUploading() {
+        MultipartFile file = new MockMultipartFile("file", "photo.jpg", "image/jpeg", new byte[512]);
+        FileUploadRequestDto request = uploadRequest(RelatedEntityType.TASK, 1L);
+
+        when(validationStrategyResolver.resolve(any())).thenReturn(validationStrategy);
+        when(validationStrategy.validate(any(), any())).thenReturn(ValidationResult.ok());
+        when(providerResolver.resolveDefault()).thenReturn(storageProvider);
+        when(storageProvider.upload(any(), anyString(), anyString())).thenReturn("task/stored.jpg");
+        when(storageProvider.getType()).thenReturn(StorageProviderType.LOCAL);
+        when(fileRepository.save(any())).thenReturn(new FileAsset());
+        when(fileMapper.toDto(any())).thenReturn(new FileResponseDto());
+
+        fileService.upload(List.of(file), request, userId);
+
+        verify(storageProvider).upload(any(), anyString(), eq("task"));
+    }
+
+    @Test
+    void upload_ShouldSetStatusAttached_WhenRelatedEntityIdIsProvided() {
+        MultipartFile file = new MockMultipartFile("file", "photo.jpg", "image/jpeg", new byte[512]);
+        FileUploadRequestDto request = uploadRequest(RelatedEntityType.NEWS, 1L);
+        ArgumentCaptor<FileAsset> captor = ArgumentCaptor.forClass(FileAsset.class);
+
+        when(validationStrategyResolver.resolve(any())).thenReturn(validationStrategy);
+        when(validationStrategy.validate(any(), any())).thenReturn(ValidationResult.ok());
+        when(providerResolver.resolveDefault()).thenReturn(storageProvider);
+        when(storageProvider.upload(any(), anyString(), anyString())).thenReturn("news/stored.jpg");
+        when(storageProvider.getType()).thenReturn(StorageProviderType.LOCAL);
+        when(fileRepository.save(any())).thenReturn(new FileAsset());
+        when(fileMapper.toDto(any())).thenReturn(new FileResponseDto());
+
+        fileService.upload(List.of(file), request, userId);
+
+        verify(fileRepository).save(captor.capture());
+        assertEquals(FileStatus.ATTACHED, captor.getValue().getStatus());
+    }
+
+    @Test
+    void upload_ShouldSetStatusTemporary_WhenRelatedEntityIdIsNull() {
+        MultipartFile file = new MockMultipartFile("file", "photo.jpg", "image/jpeg", new byte[512]);
+        FileUploadRequestDto request = uploadRequest(RelatedEntityType.NEWS, null);
+        ArgumentCaptor<FileAsset> captor = ArgumentCaptor.forClass(FileAsset.class);
+
+        when(validationStrategyResolver.resolve(any())).thenReturn(validationStrategy);
+        when(validationStrategy.validate(any(), any())).thenReturn(ValidationResult.ok());
+        when(providerResolver.resolveDefault()).thenReturn(storageProvider);
+        when(storageProvider.upload(any(), anyString(), anyString())).thenReturn("news/stored.jpg");
+        when(storageProvider.getType()).thenReturn(StorageProviderType.LOCAL);
+        when(fileRepository.save(any())).thenReturn(new FileAsset());
+        when(fileMapper.toDto(any())).thenReturn(new FileResponseDto());
+
+        fileService.upload(List.of(file), request, userId);
+
+        verify(fileRepository).save(captor.capture());
+        assertEquals(FileStatus.TEMPORARY, captor.getValue().getStatus());
+    }
+
+    @Test
+    void upload_ShouldThrowValidationException_WhenValidationFails() {
+        MultipartFile file = new MockMultipartFile("file", "photo.jpg", "image/jpeg", new byte[512]);
+        FileUploadRequestDto request = uploadRequest(RelatedEntityType.NEWS, 1L);
+
+        when(validationStrategyResolver.resolve(any())).thenReturn(validationStrategy);
+        when(validationStrategy.validate(any(), any())).thenReturn(
+            ValidationResult.fail("File size exceeded"));
+
+        var files = List.of(file);
+        ValidationException exception = assertThrows(
+            ValidationException.class, () -> fileService.upload(files, request, userId));
+
+        assertTrue(exception.getMessage().contains("File size exceeded"));
+        verifyNoInteractions(providerResolver);
+        verify(fileRepository, never()).save(any());
+    }
+
+    @Test
+    void upload_ShouldThrowFileUploadException_WhenInputStreamThrowsIOException() throws IOException {
+        MultipartFile file = mock(MultipartFile.class);
+        FileUploadRequestDto request = uploadRequest(RelatedEntityType.NEWS, 1L);
+
+        when(file.getOriginalFilename()).thenReturn("photo.jpg");
+        when(file.getInputStream()).thenThrow(new IOException("disk error"));
+        when(validationStrategyResolver.resolve(any())).thenReturn(validationStrategy);
+        when(validationStrategy.validate(any(), any())).thenReturn(ValidationResult.ok());
+        when(providerResolver.resolveDefault()).thenReturn(storageProvider);
+
+        var files = List.of(file);
+        FileUploadException exception = assertThrows(
+            FileUploadException.class, () -> fileService.upload(files, request, userId));
+
+        assertInstanceOf(IOException.class, exception.getCause());
+        verify(fileRepository, never()).save(any());
+    }
+
+    @Test
+    void upload_ShouldProcessEachFileIndependently_WhenMultipleFilesProvided() {
+        MultipartFile file1 = new MockMultipartFile("file", "a.jpg", "image/jpeg", new byte[256]);
+        MultipartFile file2 = new MockMultipartFile("file", "b.jpg", "image/jpeg", new byte[512]);
+        FileUploadRequestDto request = uploadRequest(RelatedEntityType.NEWS, 1L);
+
+        when(validationStrategyResolver.resolve(any())).thenReturn(validationStrategy);
+        when(validationStrategy.validate(any(), any())).thenReturn(ValidationResult.ok());
+        when(providerResolver.resolveDefault()).thenReturn(storageProvider);
+        when(storageProvider.upload(any(), anyString(), anyString()))
+            .thenReturn("news/a.jpg")
+            .thenReturn("news/b.jpg");
+        when(storageProvider.getType()).thenReturn(StorageProviderType.LOCAL);
+        when(fileRepository.save(any())).thenReturn(new FileAsset());
+        when(fileMapper.toDto(any()))
+            .thenReturn(FileResponseDto.builder().id(1L).build())
+            .thenReturn(FileResponseDto.builder().id(2L).build());
+
+        List<FileResponseDto> result = fileService.upload(List.of(file1, file2), request, userId);
+
+        assertEquals(2, result.size());
+        verify(storageProvider, times(2)).upload(any(), anyString(), anyString());
+        verify(fileRepository, times(2)).save(any());
+        verify(fileMapper, times(2)).toDto(any());
+    }
 
     // --- Soft Delete Tests ---
 
@@ -136,5 +334,14 @@ class FileServiceImplTest {
 
         verifyNoInteractions(providerResolver, storageProvider);
         verify(fileRepository, never()).save(any());
+    }
+
+    // --- Helpers ---
+
+    private static FileUploadRequestDto uploadRequest(RelatedEntityType type, Long relatedEntityId) {
+        return FileUploadRequestDto.builder()
+            .relatedEntityType(type)
+            .relatedEntityId(relatedEntityId)
+            .build();
     }
 }

--- a/src/test/java/com/itasocialacademy/oitassist/filemanager/validation/FileValidationStrategyResolverTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/filemanager/validation/FileValidationStrategyResolverTest.java
@@ -1,0 +1,73 @@
+package com.itasocialacademy.oitassist.filemanager.validation;
+
+import com.itasocialacademy.oitassist.core.enums.ErrorCode;
+import com.itasocialacademy.oitassist.core.exceptions.ValidationException;
+import com.itasocialacademy.oitassist.filemanager.dao.enums.RelatedEntityType;
+import com.itasocialacademy.oitassist.filemanager.validation.interfaces.FileValidationStrategy;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FileValidationStrategyResolverTest {
+
+    @Mock
+    private FileValidationStrategy newsStrategy;
+
+    @Mock
+    private FileValidationStrategy taskStrategy;
+
+    @Test
+    void resolve_ShouldReturnMatchingStrategy_WhenStrategyExists() {
+        // Arrange
+        when(newsStrategy.supports()).thenReturn(RelatedEntityType.NEWS);
+        FileValidationStrategyResolver resolver = new FileValidationStrategyResolver(List.of(newsStrategy));
+
+        // Act
+        FileValidationStrategy result = resolver.resolve(RelatedEntityType.NEWS);
+
+        // Assert
+        assertSame(newsStrategy, result);
+    }
+
+    @Test
+    void resolve_ShouldReturnCorrectStrategy_WhenMultipleStrategiesExist() {
+        // Arrange
+        when(newsStrategy.supports()).thenReturn(RelatedEntityType.NEWS);
+        when(taskStrategy.supports()).thenReturn(RelatedEntityType.TASK);
+        FileValidationStrategyResolver resolver = new FileValidationStrategyResolver(
+            List.of(newsStrategy, taskStrategy));
+
+        // Act
+        FileValidationStrategy result = resolver.resolve(RelatedEntityType.TASK);
+
+        // Assert
+        assertSame(taskStrategy, result);
+    }
+
+    @Test
+    void resolve_ShouldThrowValidationException_WhenNoStrategyMatchesType() {
+        // Arrange
+        when(newsStrategy.supports()).thenReturn(RelatedEntityType.NEWS);
+        FileValidationStrategyResolver resolver = new FileValidationStrategyResolver(List.of(newsStrategy));
+
+        // Act
+        ValidationException exception = assertThrows(
+            ValidationException.class,
+            () -> resolver.resolve(RelatedEntityType.TASK));
+
+        // Assert
+        assertAll(
+            () -> assertTrue(exception.getMessage().contains("TASK")),
+            () -> assertEquals(ErrorCode.FILE_VALIDATION_FAILED, exception.getErrorCode()));
+    }
+}

--- a/src/test/java/com/itasocialacademy/oitassist/filemanager/validation/policy/NewsFilePolicyTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/filemanager/validation/policy/NewsFilePolicyTest.java
@@ -1,0 +1,42 @@
+package com.itasocialacademy.oitassist.filemanager.validation.policy;
+
+import com.itasocialacademy.oitassist.filemanager.validation.enums.AllowedExtension;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.unit.DataSize;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NewsFilePolicyTest {
+
+    private final NewsFilePolicy policy = NewsFilePolicy.INSTANCE;
+
+    @Test
+    void getAllowedExtensions_ShouldReturnExpectedExtensions_WhenCalled() {
+        Set<AllowedExtension> expected = Set.of(
+            AllowedExtension.JPG,
+            AllowedExtension.JPEG,
+            AllowedExtension.PNG,
+            AllowedExtension.GIF,
+            AllowedExtension.WEBP);
+
+        Set<AllowedExtension> actual = policy.getAllowedExtensions();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void getMaxFileCount_ShouldReturnTen_WhenCalled() {
+        int actual = policy.getMaxFileCount();
+
+        assertEquals(10, actual);
+    }
+
+    @Test
+    void getMaxFileSize_ShouldReturnTenMegabytes_WhenCalled() {
+        DataSize actual = policy.getMaxFileSize();
+
+        assertEquals(DataSize.ofMegabytes(10), actual);
+    }
+}

--- a/src/test/java/com/itasocialacademy/oitassist/filemanager/validation/policy/TaskFilePolicyTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/filemanager/validation/policy/TaskFilePolicyTest.java
@@ -1,0 +1,41 @@
+package com.itasocialacademy.oitassist.filemanager.validation.policy;
+
+import com.itasocialacademy.oitassist.filemanager.validation.enums.AllowedExtension;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.unit.DataSize;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TaskFilePolicyTest {
+
+    private final TaskFilePolicy policy = TaskFilePolicy.INSTANCE;
+
+    @Test
+    void getAllowedExtensions_ShouldReturnExpectedExtensions_WhenCalled() {
+        Set<AllowedExtension> expected = Set.of(
+            AllowedExtension.DOCX,
+            AllowedExtension.XLSX,
+            AllowedExtension.PPTX,
+            AllowedExtension.ACCDB);
+
+        Set<AllowedExtension> actual = policy.getAllowedExtensions();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void getMaxFileCount_ShouldReturnOne_WhenCalled() {
+        int actual = policy.getMaxFileCount();
+
+        assertEquals(1, actual);
+    }
+
+    @Test
+    void getMaxFileSize_ShouldReturnFiftyMegabytes_WhenCalled() {
+        DataSize actual = policy.getMaxFileSize();
+
+        assertEquals(DataSize.ofMegabytes(50), actual);
+    }
+}

--- a/src/test/java/com/itasocialacademy/oitassist/filemanager/validation/strategies/AbstractFileValidationStrategyTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/filemanager/validation/strategies/AbstractFileValidationStrategyTest.java
@@ -1,0 +1,176 @@
+package com.itasocialacademy.oitassist.filemanager.validation.strategies;
+
+import com.itasocialacademy.oitassist.filemanager.dao.enums.RelatedEntityType;
+import com.itasocialacademy.oitassist.filemanager.dto.request.FileUploadRequestDto;
+import com.itasocialacademy.oitassist.filemanager.validation.enums.AllowedExtension;
+import com.itasocialacademy.oitassist.filemanager.validation.interfaces.FilePolicy;
+import com.itasocialacademy.oitassist.filemanager.validation.model.ValidationResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.util.unit.DataSize;
+import org.springframework.web.multipart.MultipartFile;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AbstractFileValidationStrategyTest {
+
+    @Mock
+    private FilePolicy policy;
+
+    private AbstractFileValidationStrategy strategy;
+
+    @BeforeEach
+    void setUp() {
+        strategy = new TestFileValidationStrategy(policy);
+        lenient().when(policy.getMaxFileCount()).thenReturn(5);
+        lenient().when(policy.getAllowedExtensions()).thenReturn(Set.of(AllowedExtension.JPG));
+        lenient().when(policy.getMaxFileSize()).thenReturn(DataSize.ofMegabytes(10));
+        lenient().when(policy.getRequiredFileName()).thenReturn(Optional.empty());
+    }
+
+    @Test
+    void validate_ShouldReturnOk_WhenAllFilesAreValid() {
+        // Arrange
+        List<MultipartFile> files = List.of(file("photo.jpg", 1024));
+        FileUploadRequestDto request = request();
+
+        // Act
+        ValidationResult result = strategy.validate(files, request);
+
+        // Assert
+        assertAll(
+            () -> assertTrue(result.valid()),
+            () -> assertTrue(result.violations().isEmpty()));
+    }
+
+    @Test
+    void validate_ShouldReturnFailure_WhenFileCountExceedsMaximum() {
+        // Arrange
+        when(policy.getMaxFileCount()).thenReturn(1);
+        List<MultipartFile> files = List.of(file("a.jpg", 1024), file("b.jpg", 1024));
+        FileUploadRequestDto request = request();
+
+        // Act
+        ValidationResult result = strategy.validate(files, request);
+
+        // Assert
+        assertAll(
+            () -> assertFalse(result.valid()),
+            () -> assertTrue(result.violations().stream()
+                .anyMatch(v -> v.contains("at most 1 files") && v.contains("got 2"))));
+    }
+
+    @Test
+    void validate_ShouldReturnViolation_WhenFileExtensionIsNotAllowed() {
+        // Arrange
+        List<MultipartFile> files = List.of(file("document.txt", 1024));
+        FileUploadRequestDto request = request();
+
+        // Act
+        ValidationResult result = strategy.validate(files, request);
+
+        // Assert
+        assertAll(
+            () -> assertFalse(result.valid()),
+            () -> assertTrue(result.violations().stream()
+                .anyMatch(v -> v.contains("document.txt") && v.contains("unsupported extension"))));
+    }
+
+    @Test
+    void validate_ShouldReturnViolation_WhenFileSizeExceedsLimit() {
+        // Arrange
+        when(policy.getMaxFileSize()).thenReturn(DataSize.ofMegabytes(1));
+        long twoMegabytes = DataSize.ofMegabytes(2).toBytes();
+        List<MultipartFile> files = List.of(file("photo.jpg", (int) twoMegabytes));
+        FileUploadRequestDto request = request();
+
+        // Act
+        ValidationResult result = strategy.validate(files, request);
+
+        // Assert
+        assertAll(
+            () -> assertFalse(result.valid()),
+            () -> assertTrue(result.violations().stream()
+                .anyMatch(v -> v.contains("photo.jpg") && v.contains("exceeds maximum allowed size"))));
+    }
+
+    @Test
+    void validate_ShouldReturnViolation_WhenFilenameDoesNotMatchRequired() {
+        // Arrange
+        when(policy.getRequiredFileName()).thenReturn(Optional.of("report"));
+        List<MultipartFile> files = List.of(file("photo.jpg", 1024));
+        FileUploadRequestDto request = request();
+
+        // Act
+        ValidationResult result = strategy.validate(files, request);
+
+        // Assert
+        assertAll(
+            () -> assertFalse(result.valid()),
+            () -> assertTrue(result.violations().stream()
+                .anyMatch(v -> v.contains("must be 'report'") && v.contains("got 'photo'"))));
+    }
+
+    @Test
+    void validate_ShouldAggregateViolations_WhenMultipleRulesAreBroken() {
+        // Arrange
+        when(policy.getMaxFileSize()).thenReturn(DataSize.ofMegabytes(1));
+        long twoMegabytes = DataSize.ofMegabytes(2).toBytes();
+        List<MultipartFile> files = List.of(file("document.txt", (int) twoMegabytes));
+        FileUploadRequestDto request = request();
+
+        // Act
+        ValidationResult result = strategy.validate(files, request);
+
+        // Assert
+        assertAll(
+            () -> assertFalse(result.valid()),
+            () -> assertEquals(2, result.violations().size()),
+            () -> assertTrue(result.violations().stream()
+                .anyMatch(v -> v.contains("unsupported extension"))),
+            () -> assertTrue(result.violations().stream()
+                .anyMatch(v -> v.contains("exceeds maximum allowed size"))));
+    }
+
+    // --- helpers ---
+
+    private static MockMultipartFile file(String filename, int sizeBytes) {
+        return new MockMultipartFile("file", filename, "application/octet-stream", new byte[sizeBytes]);
+    }
+
+    private static FileUploadRequestDto request() {
+        return FileUploadRequestDto.builder()
+            .relatedEntityType(RelatedEntityType.NEWS)
+            .relatedEntityId(1L)
+            .build();
+    }
+
+    // --- inner test implementation ---
+
+    private static class TestFileValidationStrategy extends AbstractFileValidationStrategy {
+        private final FilePolicy policy;
+
+        TestFileValidationStrategy(FilePolicy policy) {
+            this.policy = policy;
+        }
+
+        @Override
+        public RelatedEntityType supports() {
+            return RelatedEntityType.NEWS;
+        }
+
+        @Override
+        protected FilePolicy resolvePolicy(Long relatedEntityId) {
+            return policy;
+        }
+    }
+}

--- a/src/test/java/com/itasocialacademy/oitassist/filemanager/validation/strategies/NewsFileValidationStrategyTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/filemanager/validation/strategies/NewsFileValidationStrategyTest.java
@@ -1,0 +1,21 @@
+package com.itasocialacademy.oitassist.filemanager.validation.strategies;
+
+import com.itasocialacademy.oitassist.filemanager.dao.enums.RelatedEntityType;
+import com.itasocialacademy.oitassist.filemanager.validation.policy.NewsFilePolicy;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class NewsFileValidationStrategyTest {
+
+    private final NewsFileValidationStrategy strategy = new NewsFileValidationStrategy();
+
+    @Test
+    void supports_ShouldReturnNews_WhenCalled() {
+        assertEquals(RelatedEntityType.NEWS, strategy.supports());
+    }
+
+    @Test
+    void resolvePolicy_ShouldReturnNewsFilePolicyInstance_WhenCalled() {
+        assertSame(NewsFilePolicy.INSTANCE, strategy.resolvePolicy(1L));
+    }
+}

--- a/src/test/java/com/itasocialacademy/oitassist/filemanager/validation/strategies/TaskFileValidationStrategyTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/filemanager/validation/strategies/TaskFileValidationStrategyTest.java
@@ -1,0 +1,21 @@
+package com.itasocialacademy.oitassist.filemanager.validation.strategies;
+
+import com.itasocialacademy.oitassist.filemanager.dao.enums.RelatedEntityType;
+import com.itasocialacademy.oitassist.filemanager.validation.policy.TaskFilePolicy;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class TaskFileValidationStrategyTest {
+
+    private final TaskFileValidationStrategy strategy = new TaskFileValidationStrategy();
+
+    @Test
+    void supports_ShouldReturnTask_WhenCalled() {
+        assertEquals(RelatedEntityType.TASK, strategy.supports());
+    }
+
+    @Test
+    void resolvePolicy_ShouldReturnTaskFilePolicyInstance_WhenCalled() {
+        assertSame(TaskFilePolicy.INSTANCE, strategy.resolvePolicy(1L));
+    }
+}

--- a/src/test/java/com/itasocialacademy/oitassist/filemanager/validation/util/FileValidationUtilsTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/filemanager/validation/util/FileValidationUtilsTest.java
@@ -1,0 +1,137 @@
+package com.itasocialacademy.oitassist.filemanager.validation.util;
+
+import com.itasocialacademy.oitassist.filemanager.validation.enums.AllowedExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.util.unit.DataSize;
+import java.util.Set;
+
+import static com.itasocialacademy.oitassist.filemanager.validation.util.FileValidationUtils.extractExtension;
+import static com.itasocialacademy.oitassist.filemanager.validation.util.FileValidationUtils.extractNameWithoutExtension;
+import static com.itasocialacademy.oitassist.filemanager.validation.util.FileValidationUtils.formatAllowed;
+import static com.itasocialacademy.oitassist.filemanager.validation.util.FileValidationUtils.formatSize;
+import static com.itasocialacademy.oitassist.filemanager.validation.util.FileValidationUtils.isExtensionNotAllowed;
+import static com.itasocialacademy.oitassist.filemanager.validation.util.FileValidationUtils.isFileSizeExceeded;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FileValidationUtilsTest {
+
+    @ParameterizedTest(name = "extractExtension(\"{0}\") -> \"{1}\"")
+    @CsvSource({
+        "photo.jpg,      jpg",
+        "archive.tar.gz, gz",
+        "PHOTO.JPG,      jpg",
+        "file.,          ''",
+        "filename,       ''"
+    })
+    void extractExtension_ShouldReturnExpectedResult_WhenFilenameGiven(String filename, String expected) {
+        assertEquals(expected, extractExtension(filename));
+    }
+
+    @Test
+    void extractExtension_ShouldReturnEmpty_WhenFilenameIsNull() {
+        assertEquals("", extractExtension(null));
+    }
+
+    @Test
+    void extractExtension_ShouldReturnEmpty_WhenFilenameIsEmpty() {
+        assertEquals("", extractExtension(""));
+    }
+
+    // --- extractNameWithoutExtension ---
+
+    @ParameterizedTest(name = "extractNameWithoutExtension(\"{0}\") -> \"{1}\"")
+    @CsvSource({
+        "photo.jpg,      photo",
+        "archive.tar.gz, archive.tar",
+        "file.,          file",
+        "filename,       filename"
+    })
+    void extractNameWithoutExtension_ShouldReturnExpectedResult_WhenFilenameGiven(String filename, String expected) {
+        assertEquals(expected, extractNameWithoutExtension(filename));
+    }
+
+    @Test
+    void extractNameWithoutExtension_ShouldReturnNull_WhenFilenameIsNull() {
+        assertNull(extractNameWithoutExtension(null));
+    }
+
+    @Test
+    void extractNameWithoutExtension_ShouldReturnEmpty_WhenFilenameIsEmpty() {
+        assertEquals("", extractNameWithoutExtension(""));
+    }
+
+    // --- isExtensionNotAllowed ---
+
+    @Test
+    void isExtensionNotAllowed_ShouldReturnFalse_WhenExtensionIsInAllowedSet() {
+        assertFalse(isExtensionNotAllowed("jpg", Set.of(AllowedExtension.JPG)));
+    }
+
+    @Test
+    void isExtensionNotAllowed_ShouldReturnTrue_WhenExtensionIsNotInAllowedSet() {
+        assertTrue(isExtensionNotAllowed("txt", Set.of(AllowedExtension.JPG, AllowedExtension.PNG)));
+    }
+
+    @Test
+    void isExtensionNotAllowed_ShouldReturnTrue_WhenAllowedSetIsEmpty() {
+        assertTrue(isExtensionNotAllowed("jpg", Set.of()));
+    }
+
+    // --- formatAllowed ---
+
+    @Test
+    void formatAllowed_ShouldReturnEmpty_WhenExtensionSetIsEmpty() {
+        assertEquals("", formatAllowed(Set.of()));
+    }
+
+    @Test
+    void formatAllowed_ShouldReturnRawValue_WhenSingleExtensionProvided() {
+        assertEquals("jpg", formatAllowed(Set.of(AllowedExtension.JPG)));
+    }
+
+    @Test
+    void formatAllowed_ShouldReturnCommaSeparatedRawValues_WhenMultipleExtensionsProvided() {
+        String result = formatAllowed(Set.of(AllowedExtension.JPG, AllowedExtension.PNG));
+
+        Set<String> actual = Set.of(result.split(", "));
+        assertEquals(Set.of("jpg", "png"), actual);
+    }
+
+    // --- isFileSizeExceeded ---
+
+    @Test
+    void isFileSizeExceeded_ShouldReturnFalse_WhenFileSizeIsBelowLimit() {
+        assertFalse(isFileSizeExceeded(DataSize.ofMegabytes(1).toBytes() - 1, DataSize.ofMegabytes(1)));
+    }
+
+    @Test
+    void isFileSizeExceeded_ShouldReturnFalse_WhenFileSizeEqualsLimit() {
+        long limit = DataSize.ofMegabytes(1).toBytes();
+
+        assertFalse(isFileSizeExceeded(limit, DataSize.ofMegabytes(1)));
+    }
+
+    @Test
+    void isFileSizeExceeded_ShouldReturnTrue_WhenFileSizeExceedsLimitByOneByte() {
+        long overLimit = DataSize.ofMegabytes(1).toBytes() + 1;
+
+        assertTrue(isFileSizeExceeded(overLimit, DataSize.ofMegabytes(1)));
+    }
+
+    // --- formatSize ---
+
+    @ParameterizedTest(name = "formatSize({0}MB) -> \"{1}\"")
+    @CsvSource({
+        "1,  1MB",
+        "10, 10MB",
+        "50, 50MB"
+    })
+    void formatSize_ShouldReturnSizeWithMbSuffix_WhenCalled(long megabytes, String expected) {
+        assertEquals(expected, formatSize(DataSize.ofMegabytes(megabytes)));
+    }
+}


### PR DESCRIPTION
# OitAssist PR

Closes #197 , #200 , #201

## Summary

This PR adds unit test coverage for the file management module upload flow and validation layer.

## Changes

- added upload-related unit tests for `FileControllerTest`
- generalized `ControllerUnitTest` for better reuse
- added unit tests for file validation policies and strategies
- added unit tests for `FileValidationUtils`
- added unit tests for `FileValidationStrategyResolver`
- added upload-focused unit tests for `FileServiceImpl`
- added unit tests for `StorageProviderResolver`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for file upload functionality including validation rules, storage provider resolution, and handling of various error scenarios to ensure robust file management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->