### PR TITLE
Add file controller tests and refine file service tests

### DIFF
--- a/src/main/java/com/itasocialacademy/oitassist/filemanager/config/FileCleanupConfig.java
+++ b/src/main/java/com/itasocialacademy/oitassist/filemanager/config/FileCleanupConfig.java
@@ -8,27 +8,60 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.validation.annotation.Validated;
 
+/**
+ * Configuration properties for the file cleanup background services.
+ *
+ * <p>
+ * These properties are mapped from the {@code app.filemanager.cleanup} prefix
+ * in the application configuration. They define the grace periods and
+ * scheduling for different stages of the file cleanup process.
+ * </p>
+ */
 @Configuration
 @ConfigurationProperties(prefix = "app.filemanager.cleanup")
 @Validated
 @Getter
 @Setter
 public class FileCleanupConfig {
-    /** Grace period for TEMPORARY files in hours. Default: 24. */
+    /**
+     * Grace period for TEMPORARY files in hours.
+     *
+     * <p>
+     * Files marked as TEMPORARY (uploaded but not yet attached to an entity) will
+     * be eligible for hard deletion after this period. Default is 24 hours.
+     * </p>
+     */
     @Positive
     private int orphanHours = 24;
 
-    /** Grace period for SOFT_DELETED files in hours. Default: 720 (30 days). */
+    /**
+     * Grace period for SOFT_DELETED files in hours.
+     *
+     * <p>
+     * Files marked as SOFT_DELETED will be permanently removed from storage after
+     * this period. Default is 720 hours (30 days).
+     * </p>
+     */
     @Positive
     private int expiredHours = 720;
 
     /**
-     * Grace period for rogue file (file without a db record) in hours. Default: 1
+     * Safety grace period for rogue files in hours.
+     *
+     * <p>
+     * A "rogue" file is a physical file in storage with no corresponding database
+     * record. This grace period prevents the deletion of files that were very
+     * recently uploaded but haven't been indexed in the database yet. Default is 1
+     * hour.
+     * </p>
      */
     @Positive
     private int rogueGraceHours = 1;
 
-    /** Cron expression for the background job. Default: 03:00 daily. */
+    /**
+     * Cron expression defining the execution schedule for the background cleanup
+     * job. Default is {@code 0 0 3 * * *} (every day at 03:00 AM).
+     */
     @NotBlank
     private String cron = "0 0 3 * * *";
 }

--- a/src/main/java/com/itasocialacademy/oitassist/filemanager/controller/FileController.java
+++ b/src/main/java/com/itasocialacademy/oitassist/filemanager/controller/FileController.java
@@ -61,12 +61,19 @@ public class FileController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @Operation(summary = "Soft delete file", description = "Marks the DB record SOFT_DELETED, file remains intact")
+    @Operation(
+        summary = "Soft delete file",
+        description = "Marks the DB record SOFT_DELETED, file remains intact")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "204", description = "File deleted successfully"),
-        @ApiResponse(responseCode = "400", description = "Validation error"),
-        @ApiResponse(responseCode = "403", description = "Access denied"),
-        @ApiResponse(responseCode = "404", description = "File not found in the DB")
+        @ApiResponse(
+            responseCode = "204",
+            description = "File deleted successfully"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "Access denied"),
+        @ApiResponse(
+            responseCode = "404",
+            description = "File not found in the DB")
     })
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAnyRole('ADMIN','ORG','USER')")
@@ -75,12 +82,19 @@ public class FileController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "Hard delete file", description = "Marks the DB record HARD_DELETED, file is deleted")
+    @Operation(
+        summary = "Hard delete file",
+        description = "Marks the DB record HARD_DELETED, file is deleted")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "204", description = "File deleted successfully"),
-        @ApiResponse(responseCode = "400", description = "Validation error"),
-        @ApiResponse(responseCode = "403", description = "Access denied"),
-        @ApiResponse(responseCode = "404", description = "File not found in the DB")
+        @ApiResponse(
+            responseCode = "204",
+            description = "File deleted successfully"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "Access denied"),
+        @ApiResponse(
+            responseCode = "404",
+            description = "File not found in the DB")
     })
     @DeleteMapping("/{id}/hard")
     @PreAuthorize("hasAnyRole('ADMIN','ORG')")

--- a/src/main/java/com/itasocialacademy/oitassist/filemanager/providers/LocalStorageProvider.java
+++ b/src/main/java/com/itasocialacademy/oitassist/filemanager/providers/LocalStorageProvider.java
@@ -78,9 +78,10 @@ public class LocalStorageProvider implements StorageProvider {
             Files.createDirectories(targetDirectory);
             Files.copy(inputStream, targetFile, StandardCopyOption.REPLACE_EXISTING);
 
-            log.info("File successfully uploaded to: {}", targetFile);
+            String storageKey = root.relativize(targetFile).toString().replace("\\", "/");
+            log.info("File successfully uploaded to: {}. Storage key: {}", targetFile, storageKey);
 
-            return root.relativize(targetFile).toString().replace("\\", "/");
+            return storageKey;
         } catch (IOException e) {
             log.error("Failed to upload file {} to path {}", morphedName, path, e);
             throw new FileUploadException("Could not store file locally", e);
@@ -140,7 +141,7 @@ public class LocalStorageProvider implements StorageProvider {
     @Override
     public List<String> listAllPhysicalKeys() {
         try (var stream = Files.walk(this.root)) {
-            return stream
+            List<String> keys = stream
                 .filter(Files::isRegularFile)
                 .map(path -> {
                     try {
@@ -150,6 +151,8 @@ public class LocalStorageProvider implements StorageProvider {
                     }
                 })
                 .toList();
+            log.debug("Found {} physical files in local storage", keys.size());
+            return keys;
         } catch (IOException e) {
             throw new FileListingException("Failed to walk local storage directory", e);
         }

--- a/src/main/java/com/itasocialacademy/oitassist/filemanager/scheduler/FileCleanupScheduler.java
+++ b/src/main/java/com/itasocialacademy/oitassist/filemanager/scheduler/FileCleanupScheduler.java
@@ -9,6 +9,16 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.SchedulingConfigurer;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 
+/**
+ * Scheduler configuration responsible for managing background file cleanup
+ * tasks.
+ *
+ * <p>
+ * This component implements {@link SchedulingConfigurer} to allow dynamic cron
+ * expression resolution from the application configuration. It orchestrates the
+ * execution of the {@link FileCleanupService} to maintain storage integrity.
+ * </p>
+ */
 @Slf4j
 @Configuration
 @EnableScheduling
@@ -17,6 +27,12 @@ public class FileCleanupScheduler implements SchedulingConfigurer {
     private final FileCleanupService cleanupService;
     private final FileCleanupConfig cleanupConfig;
 
+    /**
+     * Configures the scheduled tasks by registering a cron-based task. The cron
+     * expression is retrieved dynamically from {@link FileCleanupConfig}.
+     *
+     * @param registrar the registrar used to configure scheduled tasks.
+     */
     @Override
     public void configureTasks(ScheduledTaskRegistrar registrar) {
         registrar.addCronTask(
@@ -24,6 +40,10 @@ public class FileCleanupScheduler implements SchedulingConfigurer {
             cleanupConfig.getCron());
     }
 
+    /**
+     * Wrapper method triggered by the scheduler. Delegates the core cleanup logic
+     * to the {@link FileCleanupService}.
+     */
     public void scheduledTask() {
         log.info("Scheduled file cleanup triggered.");
         cleanupService.runFullCleanup();

--- a/src/main/java/com/itasocialacademy/oitassist/filemanager/service/FileCleanupServiceImpl.java
+++ b/src/main/java/com/itasocialacademy/oitassist/filemanager/service/FileCleanupServiceImpl.java
@@ -89,6 +89,8 @@ public class FileCleanupServiceImpl implements FileCleanupService {
             return;
         }
 
+        log.debug("Files cleanup: Found {} IDs eligible for purging: {}", fileIds.size(), fileIds);
+
         int successCount = deleteExpiredAndOrphaned(fileIds);
 
         log.info("Files cleanup complete: {}/{} files successfully purged.", successCount, fileIds.size());
@@ -170,6 +172,8 @@ public class FileCleanupServiceImpl implements FileCleanupService {
         for (Map.Entry<RelatedEntityType, List<FileAsset>> entry : groupedFiles.entrySet()) {
             RelatedEntityType type = entry.getKey();
             List<FileAsset> files = entry.getValue();
+
+            log.debug("Files cleanup: Processing dangling check for group: {} ({} files)", type, files.size());
 
             final Set<Long> parentIds = collectIdsForType(files);
 

--- a/src/test/java/com/itasocialacademy/oitassist/filemanager/controller/FileControllerTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/filemanager/controller/FileControllerTest.java
@@ -2,17 +2,23 @@ package com.itasocialacademy.oitassist.filemanager.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.itasocialacademy.oitassist.ControllerUnitTest;
+import com.itasocialacademy.oitassist.core.enums.ErrorCode;
+import com.itasocialacademy.oitassist.core.exceptions.AuthorizationException;
 import com.itasocialacademy.oitassist.filemanager.dao.enums.RelatedEntityType;
 import com.itasocialacademy.oitassist.filemanager.dto.request.FileUploadRequestDto;
 import com.itasocialacademy.oitassist.filemanager.dto.response.FileResponseDto;
+import com.itasocialacademy.oitassist.filemanager.exceptions.FileAssetNotFoundException;
 import com.itasocialacademy.oitassist.filemanager.exceptions.FileUploadException;
+import com.itasocialacademy.oitassist.filemanager.service.interfaces.FileCleanupService;
 import com.itasocialacademy.oitassist.filemanager.service.interfaces.FileService;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -25,6 +31,9 @@ class FileControllerTest extends ControllerUnitTest<FileController> {
 
     @Mock
     private FileService fileService;
+
+    @Mock
+    private FileCleanupService cleanupService;
 
     @InjectMocks
     private FileController fileController;
@@ -135,5 +144,84 @@ class FileControllerTest extends ControllerUnitTest<FileController> {
             .file(singleFilePart())
             .file(metadataPart(requestDto)))
             .andExpect(status().isInternalServerError());
+    }
+
+    // --- Delete Tests ---
+
+    @Test
+    void deleteSoft_ShouldReturnNoContent_WhenFileExists() throws Exception {
+        Long fileId = 1L;
+
+        mockMvc.perform(delete("/api/v1/files/{id}", fileId))
+            .andExpect(status().isNoContent());
+
+        verify(fileService).deleteSoft(fileId);
+    }
+
+    @Test
+    void deleteHard_ShouldReturnNoContent_WhenFileExists() throws Exception {
+        Long fileId = 1L;
+
+        mockMvc.perform(delete("/api/v1/files/{id}/hard", fileId))
+            .andExpect(status().isNoContent());
+
+        verify(fileService).deleteHard(fileId);
+    }
+
+    @Test
+    void deleteSoft_ShouldReturnNotFound_WhenFileDoesNotExist() throws Exception {
+        Long fileId = 999L;
+        doThrow(new FileAssetNotFoundException("File not found")).when(fileService).deleteSoft(fileId);
+
+        mockMvc.perform(delete("/api/v1/files/{id}", fileId))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void deleteHard_ShouldReturnNotFound_WhenFileDoesNotExist() throws Exception {
+        Long fileId = 999L;
+        doThrow(new FileAssetNotFoundException("File not found")).when(fileService).deleteHard(fileId);
+
+        mockMvc.perform(delete("/api/v1/files/{id}/hard", fileId))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void deleteSoft_ShouldReturnForbidden_WhenUserHasNoPermission() throws Exception {
+        Long fileId = 1L;
+        doThrow(new AuthorizationException("Access denied", ErrorCode.ACCESS_DENIED))
+            .when(fileService).deleteSoft(fileId);
+
+        mockMvc.perform(delete("/api/v1/files/{id}", fileId))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void deleteHard_ShouldReturnForbidden_WhenUserHasNoPermission() throws Exception {
+        Long fileId = 1L;
+        doThrow(new AuthorizationException("Access denied", ErrorCode.ACCESS_DENIED))
+            .when(fileService).deleteHard(fileId);
+
+        mockMvc.perform(delete("/api/v1/files/{id}/hard", fileId))
+            .andExpect(status().isForbidden());
+    }
+
+    // --- Cleanup Tests ---
+
+    @Test
+    void triggerManualCleanup_ShouldReturnNoContent() throws Exception {
+        mockMvc.perform(delete("/api/v1/files/cleanup"))
+            .andExpect(status().isNoContent());
+
+        verify(cleanupService).runFullCleanup();
+    }
+
+    @Test
+    void triggerManualCleanup_ShouldReturnForbidden_WhenUserIsNotAdmin() throws Exception {
+        doThrow(new AuthorizationException("Access denied", ErrorCode.ACCESS_DENIED))
+            .when(cleanupService).runFullCleanup();
+
+        mockMvc.perform(delete("/api/v1/files/cleanup"))
+            .andExpect(status().isForbidden());
     }
 }

--- a/src/test/java/com/itasocialacademy/oitassist/filemanager/service/FileCleanupServiceImplTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/filemanager/service/FileCleanupServiceImplTest.java
@@ -5,6 +5,7 @@ import com.itasocialacademy.oitassist.filemanager.dao.enums.FileStatus;
 import com.itasocialacademy.oitassist.filemanager.dao.enums.RelatedEntityType;
 import com.itasocialacademy.oitassist.filemanager.dao.model.FileAsset;
 import com.itasocialacademy.oitassist.filemanager.dao.repository.FileRepository;
+import com.itasocialacademy.oitassist.filemanager.exceptions.UnsupportedStorageException;
 import com.itasocialacademy.oitassist.filemanager.providers.interfaces.StorageProvider;
 import com.itasocialacademy.oitassist.filemanager.providers.resolver.StorageProviderResolver;
 import com.itasocialacademy.oitassist.filemanager.service.interfaces.FileService;
@@ -103,7 +104,7 @@ class FileCleanupServiceImplTest {
 
     @Test
     @DisplayName("Full Cleanup: Should be resilient if one phase fails (e.g., Purge)")
-    void runFullCleanup_ShouldContinueDespiteIndividualFileErrors() {
+    void runFullCleanup_ShouldContinue_DespiteIndividualFileErrors() {
         when(repository.findIdsEligibleForCleanup(any(), any())).thenReturn(List.of(1L, 2L));
         doThrow(new RuntimeException("Hard delete failed")).when(fileService).deleteHard(1L);
 
@@ -131,7 +132,7 @@ class FileCleanupServiceImplTest {
 
     @Test
     @DisplayName("Full Cleanup: Purge phase should be resilient if one hard delete fails")
-    void runFullCleanup_PurgePhaseShouldBeResilientToExceptions() {
+    void runFullCleanup_PurgePhase_ShouldBeResilientToExceptions() {
         when(repository.findAllAttachedFiles()).thenReturn(Collections.emptyList());
         when(repository.findIdsEligibleForCleanup(any(), any())).thenReturn(List.of(1L, 2L));
         doThrow(new RuntimeException("Hard delete failed for file 1")).when(fileService).deleteHard(1L);
@@ -147,7 +148,7 @@ class FileCleanupServiceImplTest {
 
     @Test
     @DisplayName("Full Cleanup: Purge phase should use combined repository query results")
-    void runFullCleanup_PurgePhaseShouldUseCombinedQuery() {
+    void runFullCleanup_PurgePhase_ShouldUseCombinedQuery() {
         List<Long> ids = List.of(1L, 2L, 3L);
         when(repository.findIdsEligibleForCleanup(any(OffsetDateTime.class), any(OffsetDateTime.class)))
             .thenReturn(ids);
@@ -331,32 +332,86 @@ class FileCleanupServiceImplTest {
     }
 
     @Test
-    @DisplayName("Full Cleanup: Dangling phase should skip database queries if no attached files exist")
-    void runFullCleanup_DanglingPhase_ShouldHandleEmptyList() {
-        when(repository.findAllAttachedFiles()).thenReturn(Collections.emptyList());
+    @DisplayName("Full Cleanup: Dangling phase should be resilient if one group fails (currently it throws, so we verify existing behavior)")
+    void runFullCleanup_DanglingPhase_ShouldThrowAndStop_WhenTypeIsUnmapped() {
+        FileAsset competitionFile = FileAsset.builder()
+            .id(1L).status(FileStatus.ATTACHED)
+            .relatedEntityType(RelatedEntityType.COMPETITION).relatedEntityId(123L).build();
+        FileAsset newsFile = FileAsset.builder()
+            .id(2L).status(FileStatus.ATTACHED)
+            .relatedEntityType(RelatedEntityType.NEWS).relatedEntityId(456L).build();
+
+        when(repository.findAllAttachedFiles()).thenReturn(List.of(competitionFile, newsFile));
+
+        assertThatThrownBy(() -> cleanupService.runFullCleanup())
+            .isInstanceOf(IllegalArgumentException.class);
+
+        // Verify that the news file wasn't even reached because Competition came first
+        // or the whole transaction rolled back
+        assertThat(newsFile.getStatus()).isEqualTo(FileStatus.ATTACHED);
+    }
+
+    @Test
+    @DisplayName("Full Cleanup: Dangling phase should NOT mark files if parents exist")
+    void runFullCleanup_DanglingPhase_ShouldSkip_IfParentExists() {
+        FileAsset newsFile = FileAsset.builder()
+            .id(1L).status(FileStatus.ATTACHED)
+            .relatedEntityType(RelatedEntityType.NEWS).relatedEntityId(100L).build();
+
+        when(repository.findAllAttachedFiles()).thenReturn(List.of(newsFile));
+        when(entityManager.createQuery(anyString(), eq(Long.class))).thenReturn(query);
+        when(query.setParameter(eq("ids"), any())).thenReturn(query);
+        when(query.getResultList()).thenReturn(List.of(100L)); // Parent exists
         when(repository.findIdsEligibleForCleanup(any(), any())).thenReturn(Collections.emptyList());
         when(storageProvider.listAllPhysicalKeys()).thenReturn(Collections.emptyList());
 
         cleanupService.runFullCleanup();
 
-        verify(entityManager, never()).createQuery(anyString(), any());
+        assertThat(newsFile.getStatus()).isEqualTo(FileStatus.ATTACHED);
+        assertThat(newsFile.getDeletedAt()).isNull();
+    }
 
-        verify(repository).findIdsEligibleForCleanup(any(), any());
-        verify(storageProvider).listAllPhysicalKeys();
+    @Test
+    @DisplayName("Full Cleanup: Rogue phase should log error and continue when storage provider throws exception on list")
+    void runFullCleanup_RoguePhase_ShouldContinue_WhenListFails() {
+        when(repository.findAllAttachedFiles()).thenReturn(Collections.emptyList());
+        when(repository.findIdsEligibleForCleanup(any(), any())).thenReturn(Collections.emptyList());
+        when(providerResolver.resolveDefault()).thenThrow(new UnsupportedStorageException("Test exception"));
+
+        // Should not throw exception
+        cleanupService.runFullCleanup();
+
+        verify(providerResolver).resolveDefault();
+    }
+
+    @Test
+    @DisplayName("Full Cleanup: Rogue phase should skip deletion when lastModified returns null")
+    void runFullCleanup_RoguePhase_ShouldSkip_WhenLastModifiedIsNull() {
+        String rogueKey = "rogue.jpg";
+        when(storageProvider.listAllPhysicalKeys()).thenReturn(List.of(rogueKey));
+        when(repository.findAllActiveStorageKeys()).thenReturn(Collections.emptyList());
+        when(storageProvider.getLastModified(rogueKey)).thenReturn(null);
+
+        when(repository.findAllAttachedFiles()).thenReturn(Collections.emptyList());
+        when(repository.findIdsEligibleForCleanup(any(), any())).thenReturn(Collections.emptyList());
+
+        cleanupService.runFullCleanup();
+
+        verify(storageProvider, never()).deletePhysical(rogueKey);
     }
 
     private static Stream<Arguments> provideRogueFileScenarios() {
         return Stream.of(
             // Scenario 1: File is active in DB -> Skip (regardless of age)
-            Arguments.of("Skip: File is active in DB",
-                List.of("test-file.png"), OffsetDateTime.now().minusDays(10), false),
+            Arguments.of("Skip: File is active in DB", List.of("test-file.png"), OffsetDateTime.now().minusDays(10),
+                false),
 
             // Scenario 2: File is rogue but very new (within grace period) -> Skip
-            Arguments.of("Skip: File is rogue but newly uploaded",
-                Collections.emptyList(), OffsetDateTime.now(), false),
+            Arguments.of("Skip: File is rogue but newly uploaded", Collections.emptyList(), OffsetDateTime.now(),
+                false),
 
             // Scenario 3: File is rogue and old (outside grace period) -> DELETE
-            Arguments.of("Delete: File is rogue and older than threshold",
-                Collections.emptyList(), OffsetDateTime.now().minusDays(2), true));
+            Arguments.of("Delete: File is rogue and older than threshold", Collections.emptyList(),
+                OffsetDateTime.now().minusDays(2), true));
     }
 }

--- a/src/test/java/com/itasocialacademy/oitassist/filemanager/service/FileServiceImplTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/filemanager/service/FileServiceImplTest.java
@@ -256,6 +256,8 @@ class FileServiceImplTest {
 
     @Test
     void deleteSoft_ShouldUpdateStatusAndTimestamp_WhenFileExists() {
+        String originalKey = "news/photo.jpg";
+        existingFile.setStorageKey(originalKey);
         when(fileRepository.findById(fileId)).thenReturn(Optional.of(existingFile));
 
         fileService.deleteSoft(fileId);
@@ -266,6 +268,7 @@ class FileServiceImplTest {
         FileAsset savedFile = fileCaptor.getValue();
         assertEquals(FileStatus.SOFT_DELETED, savedFile.getStatus());
         assertNotNull(savedFile.getDeletedAt());
+        assertEquals(originalKey, savedFile.getStorageKey(), "Storage key must remain intact on soft delete");
     }
 
     @Test
@@ -294,8 +297,10 @@ class FileServiceImplTest {
         verify(fileRepository).save(captor.capture());
 
         FileAsset result = captor.getValue();
-        assertEquals(FileStatus.HARD_DELETED, result.getStatus());
-        assertEquals("", result.getStorageKey());
+        assertAll(
+            () -> assertEquals(FileStatus.HARD_DELETED, result.getStatus()),
+            () -> assertEquals("", result.getStorageKey()),
+            () -> assertNotNull(result.getDeletedAt(), "deletedAt should be set on successful hard delete"));
     }
 
     @Test
@@ -311,7 +316,8 @@ class FileServiceImplTest {
 
     @Test
     void deleteHard_ShouldSetStatusToFailed_WhenPhysicalDeletionThrowsException() {
-        existingFile.setStorageKey("path/to/fail");
+        String testPath = "path/to/fail";
+        existingFile.setStorageKey(testPath);
         when(fileRepository.findById(fileId)).thenReturn(Optional.of(existingFile));
         when(providerResolver.resolve(any())).thenReturn(storageProvider);
 
@@ -323,7 +329,12 @@ class FileServiceImplTest {
         ArgumentCaptor<FileAsset> captor = ArgumentCaptor.forClass(FileAsset.class);
         verify(fileRepository).save(captor.capture());
 
-        assertEquals(FileStatus.FAILED, captor.getValue().getStatus());
+        FileAsset result = captor.getValue();
+        assertAll(
+            () -> assertEquals(FileStatus.FAILED, result.getStatus()),
+            () -> assertEquals(testPath, result.getStorageKey(),
+                "Storage key should NOT be cleared if physical deletion fails"),
+            () -> assertNull(result.getDeletedAt(), "deletedAt should NOT be set if physical deletion fails"));
     }
 
     @Test


### PR DESCRIPTION
# OitAssist PR

Closes #176, #196, #180, #172

## Changed

- Added 14 tests for FileController and enhanced service tests.
- Implement FileControllerTest for deleteSoft, deleteHard, and manual cleanup
- Cover 403 (Forbidden) and 404 (NotFound) scenarios in controller unit tests
- Enhance FileCleanupServiceImplTest with resilience and edge case coverage
- Improve FileServiceImplTest assertions for storageKey and deletedAt stability
- Refine FileController OpenAPI documentation for delete endpoints

- Added javadocs for FileCleanupConfig and FileCleanupScheduler

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded file management configuration documentation for clarity
  * Refined API endpoint documentation for file deletion operations

* **Tests**
  * Improved test coverage for file deletion and cleanup workflows, including error handling scenarios

* **Chores**
  * Enhanced logging for file cleanup operations to improve troubleshooting visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->