### PR TITLE
Add technical documentation for File Management module

### DIFF
--- a/src/main/java/com/itasocialacademy/oitassist/filemanager/controller/FileController.java
+++ b/src/main/java/com/itasocialacademy/oitassist/filemanager/controller/FileController.java
@@ -1,5 +1,6 @@
 package com.itasocialacademy.oitassist.filemanager.controller;
 
+import com.itasocialacademy.oitassist.core.web.ErrorResponse;
 import com.itasocialacademy.oitassist.filemanager.dto.request.FileUploadRequestDto;
 import com.itasocialacademy.oitassist.filemanager.dto.response.FileResponseDto;
 import com.itasocialacademy.oitassist.filemanager.service.interfaces.FileCleanupService;
@@ -7,7 +8,9 @@ import com.itasocialacademy.oitassist.filemanager.service.interfaces.FileService
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Encoding;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -37,22 +40,46 @@ public class FileController {
     private final FileService fileService;
     private final FileCleanupService cleanupService;
 
+    /**
+     * Validates and uploads a batch of files, persisting their metadata and linking
+     * them to the specified entity. Returns the saved file records on success.
+     *
+     * @param files         the files to upload
+     * @param requestDto    upload context metadata (entity type and optional entity
+     *                      ID)
+     * @param currentUserId the ID of the authenticated user initiating the upload
+     * @return HTTP 201 with the list of persisted file records
+     */
+    @PostMapping(path = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(
         summary = "Upload files",
         description = """
             Uploads one or more files, stores their metadata, and links them to the specified related entity.
-            """)
-    @ApiResponse(
-        responseCode = "201",
-        description = "Files uploaded successfully",
-        content = @Content(array = @ArraySchema(schema = @Schema(implementation = FileResponseDto.class))))
-    @ApiResponse(
-        responseCode = "400",
-        description = "Invalid upload request")
-    @ApiResponse(
-        responseCode = "401",
-        description = "Unauthorized")
-    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+            """,
+        requestBody = @RequestBody(
+            content = @Content(
+                mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                encoding = @Encoding(name = "metadata", contentType = "application/json"))))
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "201",
+            description = "Files uploaded successfully",
+            content = @Content(
+                mediaType = "application/json",
+                array = @ArraySchema(schema = @Schema(implementation = FileResponseDto.class)))),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Invalid upload request",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(
+            responseCode = "401",
+            description = "Unauthorized",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)))
+    })
     public ResponseEntity<List<FileResponseDto>> upload(
         @RequestPart("files") List<MultipartFile> files,
         @RequestPart("metadata") @Valid FileUploadRequestDto requestDto,
@@ -61,6 +88,13 @@ public class FileController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
+    /**
+     * Marks the file record as SOFT_DELETED. The physical file remains in storage
+     * and will be purged during the next cleanup cycle.
+     *
+     * @param id the ID of the file to soft-delete
+     * @return HTTP 204 on success
+     */
     @Operation(
         summary = "Soft delete file",
         description = "Marks the DB record SOFT_DELETED, file remains intact")
@@ -82,6 +116,13 @@ public class FileController {
         return ResponseEntity.noContent().build();
     }
 
+    /**
+     * Permanently deletes the file from both the physical storage and the database
+     * by marking the record as HARD_DELETED.
+     *
+     * @param id the ID of the file to hard-delete
+     * @return HTTP 204 on success
+     */
     @Operation(
         summary = "Hard delete file",
         description = "Marks the DB record HARD_DELETED, file is deleted")
@@ -103,6 +144,12 @@ public class FileController {
         return ResponseEntity.noContent().build();
     }
 
+    /**
+     * Triggers the full file cleanup cycle immediately, without waiting for the
+     * next scheduled execution. Restricted to administrators.
+     *
+     * @return HTTP 204 on success
+     */
     @Operation(
         summary = "Trigger manual file cleanup",
         description = "Forces the file cleanup logic to run immediately for orphaned and expired files.")

--- a/src/main/java/com/itasocialacademy/oitassist/filemanager/providers/resolver/StorageProviderResolver.java
+++ b/src/main/java/com/itasocialacademy/oitassist/filemanager/providers/resolver/StorageProviderResolver.java
@@ -16,6 +16,14 @@ public class StorageProviderResolver {
     @Value("${storage.default-provider:LOCAL}")
     private StorageProviderType defaultProvider;
 
+    /**
+     * Resolves a {@link StorageProvider} that supports the given type.
+     *
+     * @param type the desired storage provider type
+     * @return the matching {@link StorageProvider}
+     * @throws UnsupportedStorageException if no registered provider supports the
+     *                                     given type
+     */
     public StorageProvider resolve(StorageProviderType type) {
         return providers.stream()
             .filter(p -> p.supports(type))
@@ -24,6 +32,14 @@ public class StorageProviderResolver {
                 "Unsupported storage provider: " + type));
     }
 
+    /**
+     * Resolves the default {@link StorageProvider} as configured by the
+     * {@code storage.default-provider} property (defaults to {@code LOCAL}).
+     *
+     * @return the default {@link StorageProvider}
+     * @throws UnsupportedStorageException if the configured default type has no
+     *                                     matching provider
+     */
     public StorageProvider resolveDefault() {
         return resolve(defaultProvider);
     }

--- a/src/main/java/com/itasocialacademy/oitassist/filemanager/service/FileServiceImpl.java
+++ b/src/main/java/com/itasocialacademy/oitassist/filemanager/service/FileServiceImpl.java
@@ -37,6 +37,15 @@ public class FileServiceImpl implements FileService {
     private final FileRepository repository;
     private final FileMapper fileMapper;
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>
+     * Resolves the validation strategy for the given entity type, validates all
+     * files against the applicable policy, then delegates each file to
+     * {@link #uploadSingle}.
+     * </p>
+     */
     @Override
     @Transactional
     public List<FileResponseDto> upload(List<MultipartFile> files, FileUploadRequestDto requestDto, Long userId) {
@@ -106,6 +115,17 @@ public class FileServiceImpl implements FileService {
         repository.save(file);
     }
 
+    /**
+     * Uploads a single file to the default storage provider and persists its
+     * metadata.
+     *
+     * @param file       the file to upload
+     * @param requestDto upload context metadata
+     * @param userId     the ID of the uploading user
+     * @return the persisted file record as a {@link FileResponseDto}
+     * @throws FileUploadException if the file stream cannot be read or the upload
+     *                             fails
+     */
     private FileResponseDto uploadSingle(MultipartFile file, FileUploadRequestDto requestDto, Long userId) {
         String originalFilename = file.getOriginalFilename();
         String storedFilename = generateStoredFilename(originalFilename);
@@ -134,10 +154,23 @@ public class FileServiceImpl implements FileService {
         return fileMapper.toDto(saved);
     }
 
+    /**
+     * Generates a unique filename by prepending a UUID to the original file
+     * extension.
+     *
+     * @param originalFilename the original name of the uploaded file
+     * @return a unique filename safe for storage
+     */
     private String generateStoredFilename(String originalFilename) {
         return UUID.randomUUID() + extractExtensionWithDot(originalFilename);
     }
 
+    /**
+     * Extracts the file extension including the leading dot (e.g., {@code ".pdf"}).
+     *
+     * @param originalFilename the original filename
+     * @return the extension with dot, or an empty string if no extension is present
+     */
     private String extractExtensionWithDot(String originalFilename) {
         if (originalFilename == null || !originalFilename.contains(".")) {
             return "";
@@ -145,10 +178,28 @@ public class FileServiceImpl implements FileService {
         return originalFilename.substring(originalFilename.lastIndexOf('.'));
     }
 
+    /**
+     * Builds the relative storage directory path derived from the entity type.
+     *
+     * @param requestDto the upload request containing the entity type
+     * @return a lowercase subdirectory name (e.g., {@code "news"}, {@code "task"})
+     */
     private String buildRelativePath(FileUploadRequestDto requestDto) {
         return requestDto.getRelatedEntityType().name().toLowerCase();
     }
 
+    /**
+     * Constructs a {@link FileAsset} entity from upload context data.
+     *
+     * @param file             the uploaded file
+     * @param requestDto       the upload request metadata
+     * @param originalFilename the original client-provided filename
+     * @param storedFilename   the unique filename used on disk
+     * @param storageKey       the relative storage key returned by the provider
+     * @param userId           the ID of the uploading user
+     * @param providerType     the storage provider type used for this upload
+     * @return a new {@link FileAsset} ready for persistence
+     */
     private FileAsset buildFileAsset(
         MultipartFile file,
         FileUploadRequestDto requestDto,
@@ -171,6 +222,14 @@ public class FileServiceImpl implements FileService {
             .build();
     }
 
+    /**
+     * Determines the initial {@link FileStatus} based on whether the upload is
+     * linked to a specific entity. Returns {@code TEMPORARY} when no entity ID is
+     * present, or {@code ATTACHED} when linked.
+     *
+     * @param requestDto the upload request metadata
+     * @return the appropriate initial file status
+     */
     private FileStatus resolveStatus(FileUploadRequestDto requestDto) {
         return requestDto.getRelatedEntityId() == null
             ? FileStatus.TEMPORARY

--- a/src/main/java/com/itasocialacademy/oitassist/filemanager/service/interfaces/FileService.java
+++ b/src/main/java/com/itasocialacademy/oitassist/filemanager/service/interfaces/FileService.java
@@ -15,8 +15,13 @@ public interface FileService {
      * @param userId     the ID of the user performing the upload
      * @return a list of {@link FileResponseDto} representing the persisted file
      *         records
-     * @throws com.itasocialacademy.oitassist.core.exceptions.ValidationException if any file fails the
-     *                                                                            policy validation
+     * @throws com.itasocialacademy.oitassist.core.exceptions.ValidationException if
+     *                                                                            any
+     *                                                                            file
+     *                                                                            fails
+     *                                                                            the
+     *                                                                            policy
+     *                                                                            validation
      */
     List<FileResponseDto> upload(List<MultipartFile> files, FileUploadRequestDto requestDto, Long userId);
 

--- a/src/main/java/com/itasocialacademy/oitassist/filemanager/service/interfaces/FileService.java
+++ b/src/main/java/com/itasocialacademy/oitassist/filemanager/service/interfaces/FileService.java
@@ -6,6 +6,18 @@ import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface FileService {
+    /**
+     * Validates and uploads a batch of files, linking them to the specified entity.
+     *
+     * @param files      the files to upload
+     * @param requestDto upload context metadata (entity type and optional entity
+     *                   ID)
+     * @param userId     the ID of the user performing the upload
+     * @return a list of {@link FileResponseDto} representing the persisted file
+     *         records
+     * @throws com.itasocialacademy.oitassist.core.exceptions.ValidationException if any file fails the
+     *                                                                            policy validation
+     */
     List<FileResponseDto> upload(List<MultipartFile> files, FileUploadRequestDto requestDto, Long userId);
 
     /**

--- a/src/main/java/com/itasocialacademy/oitassist/filemanager/validation/FileValidationStrategyResolver.java
+++ b/src/main/java/com/itasocialacademy/oitassist/filemanager/validation/FileValidationStrategyResolver.java
@@ -13,6 +13,22 @@ import org.springframework.stereotype.Component;
 public class FileValidationStrategyResolver {
     private final List<FileValidationStrategy> strategies;
 
+    /**
+     * Resolves the {@link FileValidationStrategy} registered for the given entity
+     * type.
+     *
+     * @param type the entity type for which a validation strategy is required
+     * @return the matching {@link FileValidationStrategy}
+     * @throws com.itasocialacademy.oitassist.core.exceptions.ValidationException if
+     *                                                                            no
+     *                                                                            strategy
+     *                                                                            is
+     *                                                                            registered
+     *                                                                            for
+     *                                                                            the
+     *                                                                            given
+     *                                                                            type
+     */
     public FileValidationStrategy resolve(RelatedEntityType type) {
         return strategies.stream()
             .filter(s -> s.supports() == type)

--- a/src/main/java/com/itasocialacademy/oitassist/filemanager/validation/interfaces/FilePolicy.java
+++ b/src/main/java/com/itasocialacademy/oitassist/filemanager/validation/interfaces/FilePolicy.java
@@ -6,12 +6,34 @@ import java.util.Set;
 import org.springframework.util.unit.DataSize;
 
 public interface FilePolicy {
+    /**
+     * Returns the set of permitted file extensions for this policy.
+     *
+     * @return allowed extensions
+     */
     Set<AllowedExtension> getAllowedExtensions();
 
+    /**
+     * Returns the maximum number of files allowed per upload request.
+     *
+     * @return max file count
+     */
     int getMaxFileCount();
 
+    /**
+     * Returns the maximum allowed size per individual file.
+     *
+     * @return max file size as a {@link DataSize}
+     */
     DataSize getMaxFileSize();
 
+    /**
+     * Returns the required filename (without extension) if the policy mandates a
+     * specific name. Returns empty if any filename is permitted.
+     *
+     * @return an {@link Optional} containing the required name, or empty if
+     *         unrestricted
+     */
     default Optional<String> getRequiredFileName() {
         return Optional.empty();
     }

--- a/src/main/java/com/itasocialacademy/oitassist/filemanager/validation/interfaces/FileValidationStrategy.java
+++ b/src/main/java/com/itasocialacademy/oitassist/filemanager/validation/interfaces/FileValidationStrategy.java
@@ -7,7 +7,20 @@ import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface FileValidationStrategy {
+    /**
+     * Returns the {@link RelatedEntityType} this strategy applies to.
+     *
+     * @return the supported entity type
+     */
     RelatedEntityType supports();
 
+    /**
+     * Validates a list of files against the rules defined for the associated entity
+     * type.
+     *
+     * @param files      the files to validate
+     * @param requestDto the upload request metadata
+     * @return a {@link ValidationResult} indicating success or listing violations
+     */
     ValidationResult validate(List<MultipartFile> files, FileUploadRequestDto requestDto);
 }

--- a/src/main/java/com/itasocialacademy/oitassist/filemanager/validation/model/ValidationResult.java
+++ b/src/main/java/com/itasocialacademy/oitassist/filemanager/validation/model/ValidationResult.java
@@ -3,14 +3,31 @@ package com.itasocialacademy.oitassist.filemanager.validation.model;
 import java.util.List;
 
 public record ValidationResult(boolean valid, List<String> violations) {
+    /**
+     * Creates a successful validation result with no violations.
+     *
+     * @return a valid {@link ValidationResult}
+     */
     public static ValidationResult ok() {
         return new ValidationResult(true, List.of());
     }
 
+    /**
+     * Creates a failed validation result with the given list of violations.
+     *
+     * @param violations the constraint violation messages
+     * @return an invalid {@link ValidationResult}
+     */
     public static ValidationResult fail(List<String> violations) {
         return new ValidationResult(false, violations);
     }
 
+    /**
+     * Creates a failed validation result with a single violation message.
+     *
+     * @param violation the constraint violation message
+     * @return an invalid {@link ValidationResult}
+     */
     public static ValidationResult fail(String violation) {
         return new ValidationResult(false, List.of(violation));
     }

--- a/src/main/java/com/itasocialacademy/oitassist/filemanager/validation/policy/NewsFilePolicy.java
+++ b/src/main/java/com/itasocialacademy/oitassist/filemanager/validation/policy/NewsFilePolicy.java
@@ -11,6 +11,9 @@ public final class NewsFilePolicy implements FilePolicy {
     private NewsFilePolicy() {
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Set<AllowedExtension> getAllowedExtensions() {
         return Set.of(
@@ -21,12 +24,18 @@ public final class NewsFilePolicy implements FilePolicy {
             AllowedExtension.WEBP);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int getMaxFileCount() {
         return 10;
     }
 
     // TODO: confirm size limit with business
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public DataSize getMaxFileSize() {
         return DataSize.ofMegabytes(10);

--- a/src/main/java/com/itasocialacademy/oitassist/filemanager/validation/policy/TaskFilePolicy.java
+++ b/src/main/java/com/itasocialacademy/oitassist/filemanager/validation/policy/TaskFilePolicy.java
@@ -11,6 +11,9 @@ public final class TaskFilePolicy implements FilePolicy {
     private TaskFilePolicy() {
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Set<AllowedExtension> getAllowedExtensions() {
         return Set.of(
@@ -20,12 +23,18 @@ public final class TaskFilePolicy implements FilePolicy {
             AllowedExtension.ACCDB);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int getMaxFileCount() {
         return 1;
     }
 
     // TODO: confirm size limit with business
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public DataSize getMaxFileSize() {
         return DataSize.ofMegabytes(50);

--- a/src/main/java/com/itasocialacademy/oitassist/filemanager/validation/strategies/AbstractFileValidationStrategy.java
+++ b/src/main/java/com/itasocialacademy/oitassist/filemanager/validation/strategies/AbstractFileValidationStrategy.java
@@ -15,8 +15,23 @@ import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
 public abstract class AbstractFileValidationStrategy implements FileValidationStrategy {
+    /**
+     * Returns the {@link FilePolicy} applicable to the given related entity.
+     *
+     * @param relatedEntityId the ID of the related entity, or {@code null} for
+     *                        temporary uploads
+     * @return the file policy to apply during validation
+     */
     protected abstract FilePolicy resolvePolicy(Long relatedEntityId);
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>
+     * Applies policy-based rules in order: file count, extension, size, and
+     * optional filename constraint.
+     * </p>
+     */
     @Override
     public ValidationResult validate(List<MultipartFile> files, FileUploadRequestDto requestDto) {
         FilePolicy policy = resolvePolicy(requestDto.getRelatedEntityId());
@@ -32,6 +47,13 @@ public abstract class AbstractFileValidationStrategy implements FileValidationSt
         return violations.isEmpty() ? ValidationResult.ok() : ValidationResult.fail(violations);
     }
 
+    /**
+     * Validates that the number of uploaded files does not exceed the policy limit.
+     *
+     * @param files      the files to validate
+     * @param policy     the applicable file policy
+     * @param violations the list to append violation messages to
+     */
     private void validateFileCount(List<MultipartFile> files, FilePolicy policy, List<String> violations) {
         if (files.size() > policy.getMaxFileCount()) {
             violations.add("Upload allows at most %d files, got %d."
@@ -39,6 +61,13 @@ public abstract class AbstractFileValidationStrategy implements FileValidationSt
         }
     }
 
+    /**
+     * Validates that the file's extension is permitted by the policy.
+     *
+     * @param file       the file to validate
+     * @param policy     the applicable file policy
+     * @param violations the list to append violation messages to
+     */
     protected void validateExtension(MultipartFile file, FilePolicy policy, List<String> violations) {
         String ext = extractExtension(file.getOriginalFilename());
         if (isExtensionNotAllowed(ext, policy.getAllowedExtensions())) {
@@ -47,6 +76,13 @@ public abstract class AbstractFileValidationStrategy implements FileValidationSt
         }
     }
 
+    /**
+     * Validates that the file size does not exceed the policy limit.
+     *
+     * @param file       the file to validate
+     * @param policy     the applicable file policy
+     * @param violations the list to append violation messages to
+     */
     private void validateSize(MultipartFile file, FilePolicy policy, List<String> violations) {
         if (isFileSizeExceeded(file.getSize(), policy.getMaxFileSize())) {
             violations.add("File '%s' exceeds maximum allowed size of %s."
@@ -54,6 +90,15 @@ public abstract class AbstractFileValidationStrategy implements FileValidationSt
         }
     }
 
+    /**
+     * Validates the file's name against the required filename specified in the
+     * policy, if present. Has no effect when the policy imposes no filename
+     * constraint.
+     *
+     * @param file       the file to validate
+     * @param policy     the applicable file policy
+     * @param violations the list to append violation messages to
+     */
     private void validateFileName(MultipartFile file, FilePolicy policy, List<String> violations) {
         policy.getRequiredFileName().ifPresent(required -> {
             String nameWithoutExt = extractNameWithoutExtension(file.getOriginalFilename());

--- a/src/main/java/com/itasocialacademy/oitassist/filemanager/validation/strategies/NewsFileValidationStrategy.java
+++ b/src/main/java/com/itasocialacademy/oitassist/filemanager/validation/strategies/NewsFileValidationStrategy.java
@@ -7,11 +7,17 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class NewsFileValidationStrategy extends AbstractFileValidationStrategy {
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public RelatedEntityType supports() {
         return RelatedEntityType.NEWS;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected FilePolicy resolvePolicy(Long relatedEntityId) {
         return NewsFilePolicy.INSTANCE;

--- a/src/main/java/com/itasocialacademy/oitassist/filemanager/validation/strategies/TaskFileValidationStrategy.java
+++ b/src/main/java/com/itasocialacademy/oitassist/filemanager/validation/strategies/TaskFileValidationStrategy.java
@@ -7,11 +7,17 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class TaskFileValidationStrategy extends AbstractFileValidationStrategy {
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public RelatedEntityType supports() {
         return RelatedEntityType.TASK;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected FilePolicy resolvePolicy(Long relatedEntityId) {
         return TaskFilePolicy.INSTANCE;

--- a/src/main/java/com/itasocialacademy/oitassist/filemanager/validation/util/FileValidationUtils.java
+++ b/src/main/java/com/itasocialacademy/oitassist/filemanager/validation/util/FileValidationUtils.java
@@ -9,6 +9,12 @@ public class FileValidationUtils {
     private FileValidationUtils() {
     }
 
+    /**
+     * Extracts the file extension (without the dot) from the given filename.
+     *
+     * @param filename the original filename
+     * @return the lowercase extension, or an empty string if none is present
+     */
     public static String extractExtension(String filename) {
         if (filename == null || !filename.contains(".")) {
             return "";
@@ -16,24 +22,60 @@ public class FileValidationUtils {
         return filename.substring(filename.lastIndexOf('.') + 1).toLowerCase();
     }
 
+    /**
+     * Checks whether the given extension is not present in the set of allowed
+     * extensions.
+     *
+     * @param ext     the file extension to check (without dot, lowercase)
+     * @param allowed the set of permitted extensions
+     * @return {@code true} if the extension is not allowed
+     */
     public static boolean isExtensionNotAllowed(String ext, Set<AllowedExtension> allowed) {
         return allowed.stream().noneMatch(e -> e.getRawValue().equals(ext));
     }
 
+    /**
+     * Formats the set of allowed extensions as a human-readable comma-separated
+     * string.
+     *
+     * @param allowed the set of permitted extensions
+     * @return a comma-separated list of extension values (e.g.,
+     *         {@code "jpg, png, gif"})
+     */
     public static String formatAllowed(Set<AllowedExtension> allowed) {
         return allowed.stream()
             .map(AllowedExtension::getRawValue)
             .collect(Collectors.joining(", "));
     }
 
+    /**
+     * Checks whether the file size exceeds the configured maximum.
+     *
+     * @param fileSize the actual file size in bytes
+     * @param maxSize  the maximum allowed size
+     * @return {@code true} if the file size exceeds the limit
+     */
     public static boolean isFileSizeExceeded(long fileSize, DataSize maxSize) {
         return fileSize > maxSize.toBytes();
     }
 
+    /**
+     * Formats a {@link DataSize} as a megabyte string (e.g., {@code "10MB"}).
+     *
+     * @param size the size to format
+     * @return the size expressed in megabytes followed by "MB"
+     */
     public static String formatSize(DataSize size) {
         return size.toMegabytes() + "MB";
     }
 
+    /**
+     * Extracts the filename without its extension.
+     *
+     * @param filename the original filename
+     * @return the portion of the name before the last dot, or the full filename if
+     *         no extension is present
+     */
     public static String extractNameWithoutExtension(String filename) {
         if (filename == null || !filename.contains(".")) {
             return filename;


### PR DESCRIPTION
# OitAssist PR

Closes #123 

## Summary

This PR adds technical documentation across the `filemanager` module to improve code readability, clarify method responsibilities, and make the upload, validation, and storage flow easier to understand.

## What was added

- Javadoc for `FileController` methods
- Javadoc for `FileService` and implementation
- Javadoc for validation strategies and policies
- Javadoc for storage provider resolver
- Javadoc for utility and helper classes

## Covered Areas

- File upload flow
- Validation strategy behavior
- Storage provider resolution
- File lifecycle handling
- Controller endpoint behavior

## Notes

- Documentation only changes
- No business logic modifications
- No API behavior changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced API documentation for file upload endpoints with clearer error handling and response schemas.

* **New Features**
  * Improved file upload validation framework with configurable file size and count limits.
  * Batch file upload support with streamlined validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->