### PR TITLE
Refactor UserStatus enum: replace legacy values with new status set

### DIFF
--- a/src/main/java/com/itasocialacademy/oitassist/auth/mapper/RegisterRequestMapper.java
+++ b/src/main/java/com/itasocialacademy/oitassist/auth/mapper/RegisterRequestMapper.java
@@ -9,7 +9,7 @@ import java.time.Instant;
 @Mapper(componentModel = "spring", imports = {Instant.class})
 public interface RegisterRequestMapper {
     @Mapping(target = "role", constant = "USER")
-    @Mapping(target = "userStatus", constant = "NOT_ACTIVATED")
+    @Mapping(target = "userStatus", constant = "PENDING")
     @Mapping(target = "createdAt", expression = "java(Instant.now())")
     @Mapping(source = "lastName", target = "surname")
     User toEntity(RegisterRequest request);

--- a/src/main/java/com/itasocialacademy/oitassist/auth/service/RegistrationServiceImpl.java
+++ b/src/main/java/com/itasocialacademy/oitassist/auth/service/RegistrationServiceImpl.java
@@ -61,7 +61,7 @@ public class RegistrationServiceImpl implements RegistrationService {
     }
 
     private void checkUserNotExists(User user) {
-        if (user.getUserStatus() == UserStatus.NOT_ACTIVATED) {
+        if (user.getUserStatus() == UserStatus.PENDING) {
             log.warn("User already registered but not activated with email={}", user.getEmail());
             throw new UserNotActivatedException();
         }

--- a/src/main/java/com/itasocialacademy/oitassist/auth/service/UserActivationServiceImpl.java
+++ b/src/main/java/com/itasocialacademy/oitassist/auth/service/UserActivationServiceImpl.java
@@ -45,11 +45,11 @@ public class UserActivationServiceImpl implements UserActivationService {
 
         User user = activationToken.getUser();
 
-        if (user.getUserStatus() == UserStatus.ACTIVATED) {
+        if (user.getUserStatus() == UserStatus.ACTIVE) {
             throw new UserAlreadyActivatedException();
         }
 
-        user.setUserStatus(UserStatus.ACTIVATED);
+        user.setUserStatus(UserStatus.ACTIVE);
         user.setUserActivationToken(null);
         userRepository.save(user);
 
@@ -130,7 +130,7 @@ public class UserActivationServiceImpl implements UserActivationService {
         User user = userRepository.findUserByEmail(email)
             .orElseThrow(UserNotFoundException::new);
 
-        if (user.getUserStatus() != UserStatus.NOT_ACTIVATED) {
+        if (user.getUserStatus() != UserStatus.PENDING) {
             throw new UserAlreadyActivatedException();
         }
 

--- a/src/main/java/com/itasocialacademy/oitassist/user/dao/enums/UserStatus.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/dao/enums/UserStatus.java
@@ -1,5 +1,5 @@
 package com.itasocialacademy.oitassist.user.dao.enums;
 
 public enum UserStatus {
-    NOT_ACTIVATED, BLOCKED, DEACTIVATED, ACTIVATED, DELETED, VERIFIED
+    PENDING, ACTIVE, INACTIVE, BLOCKED, DELETED
 }

--- a/src/main/resources/db/changelog/logs/2026-01-23-ch-create-tables-Shumeyko.xml
+++ b/src/main/resources/db/changelog/logs/2026-01-23-ch-create-tables-Shumeyko.xml
@@ -42,7 +42,7 @@
 
             ALTER TABLE users
                 ADD CONSTRAINT chk_users_status
-                    CHECK (user_status IN ('BLOCKED', 'DEACTIVATED', 'ACTIVATED', 'DELETED', 'VERIFIED', 'NOT_ACTIVATED'));
+                    CHECK (user_status IN ('PENDING', 'ACTIVE', 'INACTIVE', 'BLOCKED', 'DELETED'));
         </sql>
     </changeSet>
 

--- a/src/main/resources/db/changelog/logs/2026-01-23-ch-insert-sample-data-Shumeyko.xml
+++ b/src/main/resources/db/changelog/logs/2026-01-23-ch-insert-sample-data-Shumeyko.xml
@@ -13,7 +13,7 @@
             <column name="middle_name" value="Олегович"/>
             <column name="password" value="$2a$10$ohGnznEwIkq/G7uEmpuP5eS8xTEqgcyq6qDxGUmnJqCLfFRHAVZ1q"/>
             <column name="role" value="ADMIN"/>
-            <column name="user_status" value="VERIFIED"/>
+            <column name="user_status" value="ACTIVE"/>
         </insert>
 
         <insert tableName="users">
@@ -23,7 +23,7 @@
             <column name="middle_name" value="Петренко"/>
             <column name="password" value="$2a$10$ohGnznEwIkq/G7uEmpuP5eS8xTEqgcyq6qDxGUmnJqCLfFRHAVZ1q"/>
             <column name="role" value="USER"/>
-            <column name="user_status" value="ACTIVATED"/>
+            <column name="user_status" value="ACTIVE"/>
         </insert>
 
         <insert tableName="competitions">

--- a/src/test/java/com/itasocialacademy/oitassist/auth/mapper/RegisterRequestMapperTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/auth/mapper/RegisterRequestMapperTest.java
@@ -31,7 +31,7 @@ class RegisterRequestMapperTest {
         assertEquals("1234", user.getPassword());
         assertEquals(request.getLastName(), user.getSurname());
         assertEquals(Role.USER, user.getRole());
-        assertEquals(UserStatus.NOT_ACTIVATED, user.getUserStatus());
+        assertEquals(UserStatus.PENDING, user.getUserStatus());
         assertNotNull(user.getCreatedAt());
     }
 }

--- a/src/test/java/com/itasocialacademy/oitassist/auth/service/RegistrationServiceImplTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/auth/service/RegistrationServiceImplTest.java
@@ -51,7 +51,7 @@ class RegistrationServiceImplTest {
         RegisterRequest request = AuthTestDataFactory.validRegisterRequest();
 
         // when
-        when(user.getUserStatus()).thenReturn(UserStatus.NOT_ACTIVATED);
+        when(user.getUserStatus()).thenReturn(UserStatus.PENDING);
         when(userRepository.findUserByEmail(request.getEmail()))
             .thenReturn(Optional.of(user));
 
@@ -71,7 +71,7 @@ class RegistrationServiceImplTest {
         RegisterRequest request = AuthTestDataFactory.validRegisterRequest();
 
         // when
-        when(user.getUserStatus()).thenReturn(UserStatus.ACTIVATED);
+        when(user.getUserStatus()).thenReturn(UserStatus.ACTIVE);
         when(userRepository.findUserByEmail(request.getEmail()))
             .thenReturn(Optional.of(user));
 

--- a/src/test/java/com/itasocialacademy/oitassist/auth/service/UserActivationServiceImplTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/auth/service/UserActivationServiceImplTest.java
@@ -72,7 +72,7 @@ class UserActivationServiceImplTest {
 
         // when
         when(userRepository.findUserByEmail(email)).thenReturn(Optional.of(user));
-        when(user.getUserStatus()).thenReturn(UserStatus.ACTIVATED);
+        when(user.getUserStatus()).thenReturn(UserStatus.ACTIVE);
 
         // then
         assertThrows(UserAlreadyActivatedException.class,
@@ -90,7 +90,7 @@ class UserActivationServiceImplTest {
 
         User user = User.builder()
             .email(request.getEmail())
-            .userStatus(UserStatus.NOT_ACTIVATED)
+            .userStatus(UserStatus.PENDING)
             .build();
 
         UserActivationToken userActivationToken = UserActivationToken.generateActivationToken();
@@ -127,7 +127,7 @@ class UserActivationServiceImplTest {
         User user = User.builder()
             .email(request.getEmail())
             .userActivationToken(expiredToken)
-            .userStatus(UserStatus.NOT_ACTIVATED)
+            .userStatus(UserStatus.PENDING)
             .build();
 
         ActivationAccountEvent event =
@@ -161,7 +161,7 @@ class UserActivationServiceImplTest {
         User user = User.builder()
             .email(email)
             .userActivationToken(activationToken)
-            .userStatus(UserStatus.NOT_ACTIVATED)
+            .userStatus(UserStatus.PENDING)
             .build();
 
         try (MockedStatic<UserActivationToken> mocked = mockStatic(UserActivationToken.class)) {
@@ -194,7 +194,7 @@ class UserActivationServiceImplTest {
             .email(request.getEmail())
             .firstName(firstName)
             .userActivationToken(activationToken)
-            .userStatus(UserStatus.NOT_ACTIVATED)
+            .userStatus(UserStatus.PENDING)
             .build();
 
         ActivationAccountEvent event =


### PR DESCRIPTION
# OitAssist PR

## Summary
Closes #230 

Replaced legacy `UserStatus` enum values with a new standardized set as discussed.

## Changes
- Updated `UserStatus` enum
- Updated `chk_users_status` DB constraint in migration (in-place edit, approved by team)
- Updated sample data inserts
- Fixed hardcoded `NOT_ACTIVATED` constant in `RegisterRequestMapper`

## Testing
Dropped local DB volume, recreated container, app started successfully with new enum values applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified user account status lifecycle with updated state definitions to enhance account state tracking and management across registration, email verification, and account activation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->