### PR TITLE
feat(news): Implemented automatic archiving of published news.

### DIFF
--- a/src/main/java/com/itasocialacademy/oitassist/core/config/SchedulingConfig.java
+++ b/src/main/java/com/itasocialacademy/oitassist/core/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.itasocialacademy.oitassist.core.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/com/itasocialacademy/oitassist/core/config/TimeConfig.java
+++ b/src/main/java/com/itasocialacademy/oitassist/core/config/TimeConfig.java
@@ -9,6 +9,6 @@ import org.springframework.context.annotation.Configuration;
 public class TimeConfig {
     @Bean
     public Clock kyivClock() {
-        return Clock.system(ZoneId.of("Europe/Kiev"));
+        return Clock.system(ZoneId.of("Europe/Kyiv"));
     }
 }

--- a/src/main/java/com/itasocialacademy/oitassist/core/config/TimeConfig.java
+++ b/src/main/java/com/itasocialacademy/oitassist/core/config/TimeConfig.java
@@ -1,0 +1,14 @@
+package com.itasocialacademy.oitassist.core.config;
+
+import java.time.Clock;
+import java.time.ZoneId;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeConfig {
+    @Bean
+    public Clock kyivClock() {
+        return Clock.system(ZoneId.of("Europe/Kiev"));
+    }
+}

--- a/src/main/java/com/itasocialacademy/oitassist/news/api/scheduler/NewsArchivingScheduler.java
+++ b/src/main/java/com/itasocialacademy/oitassist/news/api/scheduler/NewsArchivingScheduler.java
@@ -1,0 +1,25 @@
+package com.itasocialacademy.oitassist.news.api.scheduler;
+
+import com.itasocialacademy.oitassist.news.service.interfaces.NewsArchivingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NewsArchivingScheduler {
+    private final NewsArchivingService newsArchivingService;
+
+    @Scheduled(cron = "${app.news.archiving.cron}", zone = "Europe/Kiev")
+    public void archivePublishedNewsNightly() {
+        try {
+            log.info("Starting nightly news archiving job");
+            int archivedCount = newsArchivingService.archiveExpiredPublishedNews();
+            log.info("Finished nightly news archiving job. Archived count={}", archivedCount);
+        } catch (Exception ex) {
+            log.error("Error during nightly news archiving job", ex);
+        }
+    }
+}

--- a/src/main/java/com/itasocialacademy/oitassist/news/dao/model/News.java
+++ b/src/main/java/com/itasocialacademy/oitassist/news/dao/model/News.java
@@ -40,6 +40,9 @@ public class News implements LongEntity {
     @Column(name = "published_at")
     private OffsetDateTime publishedAt;
 
+    @Column(name = "archived_at")
+    private OffsetDateTime archivedAt;
+
     @Column(name = "author_id", nullable = false)
     private Long authorId;
 }

--- a/src/main/java/com/itasocialacademy/oitassist/news/dao/repository/NewsRepository.java
+++ b/src/main/java/com/itasocialacademy/oitassist/news/dao/repository/NewsRepository.java
@@ -2,11 +2,30 @@ package com.itasocialacademy.oitassist.news.dao.repository;
 
 import com.itasocialacademy.oitassist.core.rest.repository.EntityRepository;
 import com.itasocialacademy.oitassist.news.dao.model.News;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NewsRepository
     extends JpaRepository<News, Long>, EntityRepository<News, Long>, JpaSpecificationExecutor<News> {
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = """
+                        UPDATE news
+                        SET status = :archivedStatus,
+                            archived_at = :archivedAt
+                        WHERE status = :publishedStatus
+                        AND published_at IS NOT NULL
+        AND CAST(published_at AT TIME ZONE 'Europe/Kyiv' AS DATE) <= :thresholdDate
+        """, nativeQuery = true)
+    int archivedPublishedNewsOlderThanOneMonth(
+        @Param("publishedStatus") String publishedStatus,
+        @Param("archivedStatus") String archivedStatus,
+        @Param("thresholdDate") LocalDate thresholdDate,
+        @Param("archivedAt") OffsetDateTime archivedAt);
 }

--- a/src/main/java/com/itasocialacademy/oitassist/news/service/NewsArchivingServiceImpl.java
+++ b/src/main/java/com/itasocialacademy/oitassist/news/service/NewsArchivingServiceImpl.java
@@ -21,18 +21,18 @@ public class NewsArchivingServiceImpl implements NewsArchivingService {
     @Transactional
     @Override
     public int archiveExpiredPublishedNews() {
-        LocalDate todayInKyiv = LocalDate.now(clock);
+        OffsetDateTime nowKyiv = OffsetDateTime.now(clock);
+        LocalDate todayInKyiv = nowKyiv.toLocalDate();
         LocalDate thresholdDate = todayInKyiv.minusDays(30);
-        OffsetDateTime archivedAt = OffsetDateTime.now(clock);
 
         int archivedCount = newsRepository.archivedPublishedNewsOlderThanOneMonth(
             NewsStatus.PUBLISHED.name(),
             NewsStatus.ARCHIVED.name(),
             thresholdDate,
-            archivedAt);
+            nowKyiv);
 
         log.info(
-            "Archived {} published news item. todayInKyiv={}, thresholdDate={}",
+            "Archived {} published news items. todayInKyiv={}, thresholdDate={}",
             archivedCount,
             todayInKyiv,
             thresholdDate);

--- a/src/main/java/com/itasocialacademy/oitassist/news/service/NewsArchivingServiceImpl.java
+++ b/src/main/java/com/itasocialacademy/oitassist/news/service/NewsArchivingServiceImpl.java
@@ -1,0 +1,41 @@
+package com.itasocialacademy.oitassist.news.service;
+
+import com.itasocialacademy.oitassist.news.dao.enums.NewsStatus;
+import com.itasocialacademy.oitassist.news.dao.repository.NewsRepository;
+import com.itasocialacademy.oitassist.news.service.interfaces.NewsArchivingService;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@AllArgsConstructor
+@Slf4j
+public class NewsArchivingServiceImpl implements NewsArchivingService {
+    private final NewsRepository newsRepository;
+    private final Clock clock;
+
+    @Transactional
+    @Override
+    public int archiveExpiredPublishedNews() {
+        LocalDate todayInKyiv = LocalDate.now(clock);
+        LocalDate thresholdDate = todayInKyiv.minusDays(30);
+        OffsetDateTime archivedAt = OffsetDateTime.now(clock);
+
+        int archivedCount = newsRepository.archivedPublishedNewsOlderThanOneMonth(
+            NewsStatus.PUBLISHED.name(),
+            NewsStatus.ARCHIVED.name(),
+            thresholdDate,
+            archivedAt);
+
+        log.info(
+            "Archived {} published news item. todayInKyiv={}, thresholdDate={}",
+            archivedCount,
+            todayInKyiv,
+            thresholdDate);
+        return archivedCount;
+    }
+}

--- a/src/main/java/com/itasocialacademy/oitassist/news/service/interfaces/NewsArchivingService.java
+++ b/src/main/java/com/itasocialacademy/oitassist/news/service/interfaces/NewsArchivingService.java
@@ -1,0 +1,5 @@
+package com.itasocialacademy.oitassist.news.service.interfaces;
+
+public interface NewsArchivingService {
+    int archiveExpiredPublishedNews();
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -108,3 +108,6 @@ app:
       expired-hours: ${APP_FILEMANAGER_CLEANUP_EXPIRED_HOURS:720}
       rogue-grace-hours: ${APP_FILEMANAGER_CLEANUP_ROGUE_GRACE_HOURS:1}
       cron: ${APP_FILEMANAGER_CLEANUP_CRON:0 0 3 * * *}
+  news:
+    archiving:
+      cron: ${APP_NEWS_ARCHIVING_CRON:0 5 0 * * *}

--- a/src/main/resources/db/changelog/logs/2026-01-23-ch-create-tables-Shumeyko.xml
+++ b/src/main/resources/db/changelog/logs/2026-01-23-ch-create-tables-Shumeyko.xml
@@ -127,6 +127,7 @@
             </column>
             <column name="published_at"
                     type="TIMESTAMPTZ"/>
+            <column name="archived_at" type="TIMESTAMPTZ"/>
             <column name="author_id" type="BIGINT">
                 <constraints nullable="false" foreignKeyName="fk_news_author" referencedTableName="users" referencedColumnNames="id" deleteCascade="false"/>
             </column>
@@ -137,6 +138,17 @@
                 ADD CONSTRAINT chk_news_status
                     CHECK (status IN ('DRAFT','PUBLISHED','ARCHIVED'));
         </sql>
+    </changeSet>
+
+    <changeSet id="create-news-status-published-at-index" author="Pavlo Cherniavskyi">
+        <createIndex indexName="idx_news_status_published_at" tableName="news">
+            <column name="status"/>
+            <column name="published_at"/>
+        </createIndex>
+
+        <rollback>
+            <dropIndex indexName="idx_news_status_published_at" tableName="news"/>
+        </rollback>
     </changeSet>
 
     <changeSet id="create-messages-table" author="Mykola Shumeyko">

--- a/src/test/java/com/itasocialacademy/oitassist/news/api/scheduler/NewsArchivingSchedulerTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/news/api/scheduler/NewsArchivingSchedulerTest.java
@@ -1,0 +1,44 @@
+package com.itasocialacademy.oitassist.news.api.scheduler;
+
+import com.itasocialacademy.oitassist.news.service.interfaces.NewsArchivingService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NewsArchivingSchedulerTest {
+    @Mock
+    private NewsArchivingService newsArchivingService;
+
+    private NewsArchivingScheduler newsArchivingScheduler;
+
+    @BeforeEach
+    void setUp() {
+        newsArchivingScheduler = new NewsArchivingScheduler(newsArchivingService);
+    }
+
+    @Test
+    void archivePublishedNewsNightly_ShouldCallArchivingService() {
+        when(newsArchivingService.archiveExpiredPublishedNews()).thenReturn(2);
+
+        newsArchivingScheduler.archivePublishedNewsNightly();
+
+        verify(newsArchivingService).archiveExpiredPublishedNews();
+    }
+
+    @Test
+    void archivePublishedNewsNightly_ShouldNotThrowException_WhenServiceFails() {
+        when(newsArchivingService.archiveExpiredPublishedNews())
+            .thenThrow(new RuntimeException("DB test error"));
+
+        assertDoesNotThrow(() -> newsArchivingScheduler.archivePublishedNewsNightly());
+
+        verify(newsArchivingService).archiveExpiredPublishedNews();
+    }
+}

--- a/src/test/java/com/itasocialacademy/oitassist/news/service/NewsArchivingServiceImplTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/news/service/NewsArchivingServiceImplTest.java
@@ -1,0 +1,71 @@
+package com.itasocialacademy.oitassist.news.service;
+
+import com.itasocialacademy.oitassist.news.dao.enums.NewsStatus;
+import com.itasocialacademy.oitassist.news.dao.repository.NewsRepository;
+import java.time.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+class NewsArchivingServiceImplTest {
+
+    @Mock
+    private NewsRepository newsRepository;
+    private NewsArchivingServiceImpl newsArchivingService;
+    private Clock clock;
+
+    @BeforeEach
+    void setUp() {
+        clock = Clock.fixed(
+            Instant.parse("2026-03-31T00:05:00Z"),
+            ZoneId.of("Europe/Kyiv"));
+        newsArchivingService = new NewsArchivingServiceImpl(newsRepository, clock);
+    }
+
+    @Test
+    void archiveExpiredPublishedNews_ShouldArchiveNewsWithCorrectThresholdDate() {
+        when(newsRepository.archivedPublishedNewsOlderThanOneMonth(
+            eq(NewsStatus.PUBLISHED.name()),
+            eq(NewsStatus.ARCHIVED.name()),
+            eq(LocalDate.of(2026, 3, 1)),
+            any(OffsetDateTime.class))).thenReturn(3);
+
+        int result = newsArchivingService.archiveExpiredPublishedNews();
+
+        assertEquals(3, result);
+
+        verify(newsRepository).archivedPublishedNewsOlderThanOneMonth(
+            eq(NewsStatus.PUBLISHED.name()),
+            eq(NewsStatus.ARCHIVED.name()),
+            eq(LocalDate.of(2026, 3, 1)),
+            any(OffsetDateTime.class));
+    }
+
+    @Test
+    void archiveExpiredPublishedNews_ShouldReturnZero_WhenNoNewsArchived() {
+        when(newsRepository.archivedPublishedNewsOlderThanOneMonth(
+            eq(NewsStatus.PUBLISHED.name()),
+            eq(NewsStatus.ARCHIVED.name()),
+            eq(LocalDate.of(2026, 3, 1)),
+            any(OffsetDateTime.class))).thenReturn(0);
+
+        int result = newsArchivingService.archiveExpiredPublishedNews();
+
+        assertEquals(0, result);
+
+        verify(newsRepository).archivedPublishedNewsOlderThanOneMonth(
+            eq(NewsStatus.PUBLISHED.name()),
+            eq(NewsStatus.ARCHIVED.name()),
+            eq(LocalDate.of(2026, 3, 1)),
+            any(OffsetDateTime.class));
+    }
+}


### PR DESCRIPTION
Description

Implemented automatic archiving of published news.

Changes

Added scheduled job to archive news after 30 calendar days (on the 31st day)
Implemented NewsArchivingService with business logic for archiving
Added native query in NewsRepository to update expired published news
Introduced archived_at field for tracking archive time
Configured scheduler to run daily (cron configurable via APP_NEWS_ARCHIVING_CRON)
Added unit tests for service and scheduler

Notes

Archiving is based on Europe/Kyiv timezone
Only PUBLISHED news with non-null published_at are processed
Operation is idempotent and safe for repeated execution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated nightly archiving system for expired published news. News published over 30 days ago is automatically archived at a configurable time (defaults to 5 AM daily, Kyiv timezone). Archived timestamp is recorded for each item.

* **Tests**
  * Comprehensive test coverage for news archiving scheduler and service, including error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->