### PR TITLE
Implement archived news grouping endpoint,wrote tests

### DIFF
--- a/src/main/java/com/itasocialacademy/oitassist/news/controller/NewsController.java
+++ b/src/main/java/com/itasocialacademy/oitassist/news/controller/NewsController.java
@@ -4,8 +4,10 @@ import com.itasocialacademy.oitassist.core.dao.dto.response.PageResponse;
 import com.itasocialacademy.oitassist.core.rest.controller.AbstractRestControllerImpl;
 import com.itasocialacademy.oitassist.news.dao.dto.request.CreateNewsDTO;
 import com.itasocialacademy.oitassist.news.dao.dto.request.UpdateNewsDto;
+import com.itasocialacademy.oitassist.news.dao.dto.response.ArchivedNewsByYearDto;
 import com.itasocialacademy.oitassist.news.dao.dto.response.ResponseNewsDto;
 import com.itasocialacademy.oitassist.news.dao.dto.response.ResponseNewsListItemDto;
+import com.itasocialacademy.oitassist.news.service.interfaces.NewsArchivingService;
 import com.itasocialacademy.oitassist.news.service.interfaces.NewsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -15,6 +17,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.time.LocalDate;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -28,8 +31,11 @@ import static org.springframework.data.domain.Sort.Direction.DESC;
 @RequestMapping("/api/v1/news")
 public class NewsController
     extends AbstractRestControllerImpl<Long, CreateNewsDTO, UpdateNewsDto, ResponseNewsDto, NewsService> {
-    protected NewsController(NewsService service) {
+    private final NewsArchivingService newsArchivingService;
+
+    protected NewsController(NewsService service, NewsArchivingService newsArchivingService) {
         super(service);
+        this.newsArchivingService = newsArchivingService;
     }
 
     @Operation(summary = "Create news", description = "Creates a new news item")
@@ -108,5 +114,17 @@ public class NewsController
         @RequestParam(required = false) String search,
         @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
         return ResponseEntity.ok(PageResponse.from(service.getPublishedNews(pageable, search, date)));
+    }
+
+    @Operation(
+        summary = "Get archived news",
+        description = "Returns list of archived news grouped by year and month")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Archived news retrieved successfully")
+    })
+    @GetMapping("/archive")
+    @PreAuthorize("hasAnyRole('ADMIN','ORG')")
+    public ResponseEntity<List<ArchivedNewsByYearDto>> getArchivedNews() {
+        return ResponseEntity.ok(newsArchivingService.getArchivedNewsGroupedByYearAndMonth());
     }
 }

--- a/src/main/java/com/itasocialacademy/oitassist/news/dao/dto/response/ArchivedNewsByMonthDto.java
+++ b/src/main/java/com/itasocialacademy/oitassist/news/dao/dto/response/ArchivedNewsByMonthDto.java
@@ -1,0 +1,8 @@
+package com.itasocialacademy.oitassist.news.dao.dto.response;
+
+import java.util.List;
+
+public record ArchivedNewsByMonthDto(
+    int month,
+    List<ResponseNewsListItemDto> news) {
+}

--- a/src/main/java/com/itasocialacademy/oitassist/news/dao/dto/response/ArchivedNewsByYearDto.java
+++ b/src/main/java/com/itasocialacademy/oitassist/news/dao/dto/response/ArchivedNewsByYearDto.java
@@ -1,0 +1,8 @@
+package com.itasocialacademy.oitassist.news.dao.dto.response;
+
+import java.util.List;
+
+public record ArchivedNewsByYearDto(
+    int year,
+    List<ArchivedNewsByMonthDto> months) {
+}

--- a/src/main/java/com/itasocialacademy/oitassist/news/dao/dto/response/ResponseNewsListItemDto.java
+++ b/src/main/java/com/itasocialacademy/oitassist/news/dao/dto/response/ResponseNewsListItemDto.java
@@ -3,15 +3,13 @@ package com.itasocialacademy.oitassist.news.dao.dto.response;
 import com.itasocialacademy.oitassist.core.rest.dto.EntityDTO;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.OffsetDateTime;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Setter
+@Builder
 @Schema(description = "DTO representing news list item response")
 public class ResponseNewsListItemDto implements EntityDTO<Long> {
     @Schema(description = "Unique identifier of the news")
@@ -22,4 +20,6 @@ public class ResponseNewsListItemDto implements EntityDTO<Long> {
     private String contentPreview;
     @Schema(description = "Date and time when the news was published")
     private OffsetDateTime publishedAt;
+    @Schema(description = "Date and time when the news was archived")
+    private OffsetDateTime archivedAt;
 }

--- a/src/main/java/com/itasocialacademy/oitassist/news/dao/repository/NewsRepository.java
+++ b/src/main/java/com/itasocialacademy/oitassist/news/dao/repository/NewsRepository.java
@@ -4,6 +4,7 @@ import com.itasocialacademy.oitassist.core.rest.repository.EntityRepository;
 import com.itasocialacademy.oitassist.news.dao.model.News;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
@@ -28,4 +29,13 @@ public interface NewsRepository
         @Param("archivedStatus") String archivedStatus,
         @Param("thresholdDate") LocalDate thresholdDate,
         @Param("archivedAt") OffsetDateTime archivedAt);
+
+    @Query("""
+            SELECT n
+            FROM News n
+            WHERE n.status = com.itasocialacademy.oitassist.news.dao.enums.NewsStatus.ARCHIVED
+              AND n.archivedAt IS NOT NULL
+            ORDER BY n.archivedAt DESC
+        """)
+    List<News> findArchivedNewsOrderByArchivedAtDesc();
 }

--- a/src/main/java/com/itasocialacademy/oitassist/news/service/NewsArchivingServiceImpl.java
+++ b/src/main/java/com/itasocialacademy/oitassist/news/service/NewsArchivingServiceImpl.java
@@ -51,7 +51,7 @@ public class NewsArchivingServiceImpl implements NewsArchivingService {
             Comparator.reverseOrder());
 
         for (News news : archivedNews) {
-            YearMonth yearMonth = YearMonth.from(news.getArchivedAt().atZoneSameInstant(ZoneId.of("Europe/Kiev")));
+            YearMonth yearMonth = YearMonth.from(news.getArchivedAt().atZoneSameInstant(ZoneId.of("Europe/Kyiv")));
 
             grouped
                 .computeIfAbsent(yearMonth.getYear(), year -> new TreeMap<>(Comparator.reverseOrder()))

--- a/src/main/java/com/itasocialacademy/oitassist/news/service/NewsArchivingServiceImpl.java
+++ b/src/main/java/com/itasocialacademy/oitassist/news/service/NewsArchivingServiceImpl.java
@@ -1,11 +1,14 @@
 package com.itasocialacademy.oitassist.news.service;
 
+import com.itasocialacademy.oitassist.news.dao.dto.response.ArchivedNewsByMonthDto;
+import com.itasocialacademy.oitassist.news.dao.dto.response.ArchivedNewsByYearDto;
+import com.itasocialacademy.oitassist.news.dao.dto.response.ResponseNewsListItemDto;
 import com.itasocialacademy.oitassist.news.dao.enums.NewsStatus;
+import com.itasocialacademy.oitassist.news.dao.model.News;
 import com.itasocialacademy.oitassist.news.dao.repository.NewsRepository;
 import com.itasocialacademy.oitassist.news.service.interfaces.NewsArchivingService;
-import java.time.Clock;
-import java.time.LocalDate;
-import java.time.OffsetDateTime;
+import java.time.*;
+import java.util.*;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -37,5 +40,49 @@ public class NewsArchivingServiceImpl implements NewsArchivingService {
             todayInKyiv,
             thresholdDate);
         return archivedCount;
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<ArchivedNewsByYearDto> getArchivedNewsGroupedByYearAndMonth() {
+        List<News> archivedNews = newsRepository.findArchivedNewsOrderByArchivedAtDesc();
+
+        Map<Integer, Map<Integer, List<ResponseNewsListItemDto>>> grouped = new TreeMap<>(
+            Comparator.reverseOrder());
+
+        for (News news : archivedNews) {
+            YearMonth yearMonth = YearMonth.from(news.getArchivedAt().atZoneSameInstant(ZoneId.of("Europe/Kiev")));
+
+            grouped
+                .computeIfAbsent(yearMonth.getYear(), year -> new TreeMap<>(Comparator.reverseOrder()))
+                .computeIfAbsent(yearMonth.getMonthValue(), month -> new ArrayList<>())
+                .add(toNewsListItemDto(news));
+        }
+        List<ArchivedNewsByYearDto> result = grouped.entrySet().stream()
+            .map(yearEntry -> new ArchivedNewsByYearDto(
+                yearEntry.getKey(),
+                yearEntry.getValue().entrySet().stream()
+                    .map(monthEntry -> new ArchivedNewsByMonthDto(
+                        monthEntry.getKey(),
+                        monthEntry.getValue()))
+                    .toList()))
+            .toList();
+
+        log.info(
+            "Fetched archived news grouped by year and month. newsCount={}, yearGroupsCount={}",
+            archivedNews.size(),
+            result.size());
+
+        return result;
+    }
+
+    private ResponseNewsListItemDto toNewsListItemDto(News news) {
+        return ResponseNewsListItemDto.builder()
+            .id(news.getId())
+            .title(news.getTitle())
+            .publishedAt(news.getPublishedAt())
+            .contentPreview(news.getContent())
+            .archivedAt(news.getArchivedAt())
+            .build();
     }
 }

--- a/src/main/java/com/itasocialacademy/oitassist/news/service/NewsServiceImpl.java
+++ b/src/main/java/com/itasocialacademy/oitassist/news/service/NewsServiceImpl.java
@@ -84,7 +84,8 @@ public class NewsServiceImpl
             news.getId(),
             news.getTitle(),
             buildPreview(news.getContent()),
-            news.getPublishedAt());
+            news.getPublishedAt(),
+            news.getArchivedAt());
     }
 
     private String buildPreview(String content) {

--- a/src/main/java/com/itasocialacademy/oitassist/news/service/interfaces/NewsArchivingService.java
+++ b/src/main/java/com/itasocialacademy/oitassist/news/service/interfaces/NewsArchivingService.java
@@ -1,5 +1,10 @@
 package com.itasocialacademy.oitassist.news.service.interfaces;
 
+import com.itasocialacademy.oitassist.news.dao.dto.response.ArchivedNewsByYearDto;
+import java.util.List;
+
 public interface NewsArchivingService {
     int archiveExpiredPublishedNews();
+
+    List<ArchivedNewsByYearDto> getArchivedNewsGroupedByYearAndMonth();
 }

--- a/src/test/java/com/itasocialacademy/oitassist/news/controller/NewsControllerTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/news/controller/NewsControllerTest.java
@@ -144,7 +144,8 @@ class NewsControllerTest {
             1L,
             "Published news title",
             "Short preview text...",
-            OffsetDateTime.parse("2026-03-12T13:44:56Z"));
+            OffsetDateTime.parse("2026-03-12T13:44:56Z"),
+            null);
 
         Page<ResponseNewsListItemDto> page = new PageImpl<>(
             List.of(newsItem),
@@ -196,7 +197,8 @@ class NewsControllerTest {
             10L,
             "Tech News",
             "Latest on technology...",
-            OffsetDateTime.parse("2026-03-20T15:30:00Z"));
+            OffsetDateTime.parse("2026-03-20T15:30:00Z"),
+            null);
 
         Page<ResponseNewsListItemDto> page = new PageImpl<>(
             List.of(item),

--- a/src/test/java/com/itasocialacademy/oitassist/news/controller/NewsControllerTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/news/controller/NewsControllerTest.java
@@ -159,6 +159,7 @@ class NewsControllerTest {
             .andExpect(jsonPath("$.content[0].id").value(1))
             .andExpect(jsonPath("$.content[0].title").value("Published news title"))
             .andExpect(jsonPath("$.content[0].contentPreview").value("Short preview text..."))
+            .andExpect(jsonPath("$.content[0].archivedAt").isEmpty())
             .andExpect(jsonPath("$.pageNumber").value(0))
             .andExpect(jsonPath("$.pageSize").value(5))
             .andExpect(jsonPath("$.totalPages").value(1))
@@ -212,6 +213,7 @@ class NewsControllerTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.content[0].id").value(10))
             .andExpect(jsonPath("$.content[0].title").value("Tech News"))
+            .andExpect(jsonPath("$.content[0].archivedAt").isEmpty())
             .andExpect(jsonPath("$.totalElements").value(1));
 
         verify(newsService).getPublishedNews(any(), eq(search), eq(null));

--- a/src/test/java/com/itasocialacademy/oitassist/news/service/NewsArchivingServiceImplTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/news/service/NewsArchivingServiceImplTest.java
@@ -1,8 +1,11 @@
 package com.itasocialacademy.oitassist.news.service;
 
+import com.itasocialacademy.oitassist.news.dao.dto.response.ArchivedNewsByYearDto;
 import com.itasocialacademy.oitassist.news.dao.enums.NewsStatus;
+import com.itasocialacademy.oitassist.news.dao.model.News;
 import com.itasocialacademy.oitassist.news.dao.repository.NewsRepository;
 import java.time.*;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.mockito.ArgumentMatchers.eq;
@@ -67,5 +71,65 @@ class NewsArchivingServiceImplTest {
             eq(NewsStatus.ARCHIVED.name()),
             eq(LocalDate.of(2026, 3, 1)),
             any(OffsetDateTime.class));
+    }
+
+    @Test
+    void getArchivedNewsGroupedByYearAndMonth_ShouldReturnEmptyList_WhenNoArchivedNews() {
+        when(newsRepository.findArchivedNewsOrderByArchivedAtDesc()).thenReturn(List.of());
+
+        List<ArchivedNewsByYearDto> result = newsArchivingService.getArchivedNewsGroupedByYearAndMonth();
+
+        assertTrue(result.isEmpty());
+
+        verify(newsRepository).findArchivedNewsOrderByArchivedAtDesc();
+    }
+
+    @Test
+    void getArchivedNewsGroupedByYearAndMonth_ShouldGroupNewsByYearAndMonthInDescendingOrder() {
+        News news2026May = buildArchivedNews(
+            1L,
+            "News 2026 May",
+            OffsetDateTime.parse("2026-05-10T10:00:00+03:00"));
+
+        News news2026April = buildArchivedNews(
+            2L,
+            "News 2026 April",
+            OffsetDateTime.parse("2026-04-10T10:00:00+03:00"));
+
+        News news2025December = buildArchivedNews(
+            3L,
+            "News 2025 December",
+            OffsetDateTime.parse("2025-12-10T10:00:00+02:00"));
+
+        when(newsRepository.findArchivedNewsOrderByArchivedAtDesc())
+            .thenReturn(List.of(news2025December, news2026April, news2026May));
+
+        List<ArchivedNewsByYearDto> result = newsArchivingService.getArchivedNewsGroupedByYearAndMonth();
+
+        assertEquals(2, result.size());
+
+        assertEquals(2026, result.get(0).year());
+        assertEquals(2025, result.get(1).year());
+
+        assertEquals(2, result.get(0).months().size());
+        assertEquals(5, result.get(0).months().get(0).month());
+        assertEquals(4, result.get(0).months().get(1).month());
+
+        assertEquals(1, result.get(0).months().get(0).news().size());
+        assertEquals("News 2026 May", result.get(0).months().get(0).news().get(0).getTitle());
+
+        assertEquals(12, result.get(1).months().get(0).month());
+        assertEquals("News 2025 December", result.get(1).months().get(0).news().get(0).getTitle());
+    }
+
+    private News buildArchivedNews(Long id, String title, OffsetDateTime archivedAt) {
+        News news = new News();
+        news.setId(id);
+        news.setTitle(title);
+        news.setContent("Some content for preview");
+        news.setStatus(NewsStatus.ARCHIVED);
+        news.setPublishedAt(archivedAt.minusDays(30));
+        news.setArchivedAt(archivedAt);
+        return news;
     }
 }

--- a/src/test/java/com/itasocialacademy/oitassist/news/service/NewsArchivingServiceImplTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/news/service/NewsArchivingServiceImplTest.java
@@ -122,6 +122,23 @@ class NewsArchivingServiceImplTest {
         assertEquals("News 2025 December", result.get(1).months().get(0).news().get(0).getTitle());
     }
 
+    @Test
+    void getArchivedNewsGroupedByYearAndMonth_ShouldGroupByKyivTimezone() {
+        News news = buildArchivedNews(
+            1L,
+            "Kyiv timezone news",
+            OffsetDateTime.parse("2026-04-30T22:30:00Z")
+        );
+
+        when(newsRepository.findArchivedNewsOrderByArchivedAtDesc()).thenReturn(List.of(news));
+
+        List<ArchivedNewsByYearDto> result = newsArchivingService.getArchivedNewsGroupedByYearAndMonth();
+
+        assertEquals(1, result.size());
+        assertEquals(2026, result.get(0).year());
+        assertEquals(5, result.get(0).months().get(0).month());
+    }
+
     private News buildArchivedNews(Long id, String title, OffsetDateTime archivedAt) {
         News news = new News();
         news.setId(id);


### PR DESCRIPTION
# OitAssist PR
Changes:
- Added GET /news/archive endpoint
- Added DTOs for grouping archived news by year and month
- Added service logic to group archived news using Europe/Kyiv timezone
- Added repository method to fetch archived news
- Added logs for archived news grouping
- Added unit tests for archived news grouping logic

Notes:
- Years are sorted in descending order
- Months within each year are sorted in descending order
- Empty years/months are not included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new authenticated API endpoint to retrieve archived news, organized by year and month for improved browsing and discovery.
  * News items now include archival date information in responses, allowing users to see when articles were archived.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->