### PR TITLE
fix: escape Discord notification payload and handle reopened PRs

### DIFF
--- a/.github/workflows/pr-to-discord.yml
+++ b/.github/workflows/pr-to-discord.yml
@@ -2,7 +2,7 @@ name: PR to Discord
 
 on:
   pull_request:
-    types: [opened, closed]
+    types: [ opened, reopened, closed ]
     branches: [ dev ]
 
 permissions:
@@ -17,21 +17,23 @@ jobs:
 
       # --- STEP 1: OPENED ---
       - name: Notify and Label
-        if: github.event.action == 'opened'
+        if: github.event.action == 'opened' || github.event.action == 'reopened'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DISCORD_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
-          RESPONSE=$(curl -s -X POST "${DISCORD_URL}?wait=true" \
-            -H "Content-Type: application/json" \
-            -d @- <<EOF
-          {
-            "content": "🚀 **New PR #${{ github.event.pull_request.number }}**\n👀**Title:** ${{ github.event.pull_request.title }}\n👤**Author:** ${{ github.event.pull_request.user.login }}\n🔗**Link:** ${{ github.event.pull_request.html_url }}"
-          }
-          EOF
-          )
+          PAYLOAD=$(jq -n \
+            --arg content "🚀 **New PR #${{ github.event.pull_request.number }}**
+          👀**Title:** ${{ github.event.pull_request.title }}
+          👤**Author:** ${{ github.event.pull_request.user.login }}
+          🔗**Link:** ${{ github.event.pull_request.html_url }}" \
+          '{content: $content}')
           
-          MSG_ID=$(echo $RESPONSE | jq -r '.id')
+          RESPONSE=$(curl -s -X POST "${DISCORD_URL}?wait=true" \
+          -H "Content-Type: application/json" \
+          -d "$PAYLOAD")
+          
+          MSG_ID=$(echo "$RESPONSE" | jq -r '.id')
           
           if [ "$MSG_ID" == "null" ] || [ -z "$MSG_ID" ]; then
             echo "Error: Discord did not return a Message ID. Response was: $RESPONSE"

--- a/.github/workflows/pr-to-discord.yml
+++ b/.github/workflows/pr-to-discord.yml
@@ -21,17 +21,27 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DISCORD_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           PAYLOAD=$(jq -n \
-            --arg content "🚀 **New PR #${{ github.event.pull_request.number }}**
-          👀**Title:** ${{ github.event.pull_request.title }}
-          👤**Author:** ${{ github.event.pull_request.user.login }}
-          🔗**Link:** ${{ github.event.pull_request.html_url }}" \
-          '{content: $content}')
+            --arg number "$PR_NUMBER" \
+            --arg title "$PR_TITLE" \
+            --arg author "$PR_AUTHOR" \
+            --arg url "$PR_URL" \
+            '{
+              content:
+                ("🚀 **New PR #" + $number + "**\n" +
+                 "👀**Title:** " + $title + "\n" +
+                 "👤**Author:** " + $author + "\n" +
+                 "🔗**Link:** " + $url)
+            }')
           
           RESPONSE=$(curl -s -X POST "${DISCORD_URL}?wait=true" \
-          -H "Content-Type: application/json" \
-          -d "$PAYLOAD")
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD")
           
           MSG_ID=$(echo "$RESPONSE" | jq -r '.id')
           
@@ -42,25 +52,26 @@ jobs:
 
           LABEL_NAME="discord-$MSG_ID"
           
-          gh label create "$LABEL_NAME" --color "7289da" --repo ${{ github.repository }} || echo "Label exists"
-          gh pr edit ${{ github.event.pull_request.number }} --add-label "$LABEL_NAME" --repo ${{ github.repository }}
+          gh label create "$LABEL_NAME" --color "7289da" --repo "$GITHUB_REPOSITORY" || echo "Label exists"
+          gh pr edit "$PR_NUMBER" --add-label "$LABEL_NAME" --repo "$GITHUB_REPOSITORY"
 
       # --- STEP 2: CLOSED ---
       - name: Delete Discord Message
-        if: github.event.action == 'closed' || github.event.action == 'merged'
+        if: github.event.action == 'closed' || github.event.pull_request.merged == true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DISCORD_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          LABELS=$(gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json labels -q '.labels[].name')
-          
+          LABELS=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json labels -q '.labels[].name')
+
           MSG_ID=$(echo "$LABELS" | grep -oP '(?<=discord-)\d+' || echo "")
           
           if [ ! -z "$MSG_ID" ]; then
             echo "Deleting message $MSG_ID..."
             curl -s -X DELETE "${DISCORD_URL}/messages/$MSG_ID"
           
-            gh label delete "discord-$MSG_ID" --repo ${{ github.repository }} --yes
+            gh label delete "discord-$MSG_ID" --repo "$GITHUB_REPOSITORY" --yes
           else
             echo "No valid Discord ID label found (found: $LABELS)"
           fi


### PR DESCRIPTION
# OitAssist PR
## Issue Link 📋
<a href="https://github.com/ita-social-projects/oitAssist/issues/278">#278</a>

## Changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the GitHub Actions workflow for Discord pull request notifications to also handle reopened pull requests.
  * Improved webhook payload construction and standardized message ID extraction.
  * Adjusted message deletion logic for closed vs. merged pull requests and standardized repository scoping for labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->