### PR TITLE
[Feature] Add user role management endpoint for admins

### DIFF
--- a/src/main/java/com/itasocialacademy/oitassist/core/enums/ErrorCode.java
+++ b/src/main/java/com/itasocialacademy/oitassist/core/enums/ErrorCode.java
@@ -47,7 +47,10 @@ public enum ErrorCode {
     ACTIVATION_EMAIL_SENDING_TIMEOUT(ErrorCategory.VALIDATION),
     USER_ALREADY_ACTIVATED(ErrorCategory.CONFLICT),
     USER_NOT_ACTIVATED(ErrorCategory.CONFLICT),
-    ACCESS_DENIED(ErrorCategory.AUTHORIZATION);
+    ACCESS_DENIED(ErrorCategory.AUTHORIZATION),
+
+    USER_ROLE_SELF_CHANGE(ErrorCategory.AUTHORIZATION),
+    ADMIN_ROLE_MODIFICATION_RESTRICTED(ErrorCategory.AUTHORIZATION);
 
     private final ErrorCategory category;
 }

--- a/src/main/java/com/itasocialacademy/oitassist/core/exceptions/InsufficientPermissionsException.java
+++ b/src/main/java/com/itasocialacademy/oitassist/core/exceptions/InsufficientPermissionsException.java
@@ -1,0 +1,18 @@
+package com.itasocialacademy.oitassist.core.exceptions;
+
+import com.itasocialacademy.oitassist.core.enums.ErrorCode;
+
+/**
+ * Thrown when a user attempts to perform an action without sufficient
+ * permissions according to business rules.
+ *
+ * <p>
+ * This exception should be used for domain-level access restrictions, such as
+ * attempting to modify protected resources or roles.
+ * </p>
+ */
+public class InsufficientPermissionsException extends BusinessException {
+    public InsufficientPermissionsException() {
+        super("You do not have enough permissions to perform this action", ErrorCode.ACCESS_DENIED);
+    }
+}

--- a/src/main/java/com/itasocialacademy/oitassist/user/controller/UserController.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/controller/UserController.java
@@ -74,6 +74,16 @@ public class UserController
                         }
                     """))),
         @ApiResponse(
+            responseCode = "401",
+            description = "Unauthorized - token is missing or invalid",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(example = """
+                        {
+                            "message": "Full authentication is required to access this resource"
+                        }
+                    """))),
+        @ApiResponse(
             responseCode = "403",
             description = "Forbidden - insufficient permissions or attempt to modify restricted user",
             content = @Content(

--- a/src/main/java/com/itasocialacademy/oitassist/user/controller/UserController.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.itasocialacademy.oitassist.user.controller;
 
 import com.itasocialacademy.oitassist.core.rest.controller.AbstractRestControllerImpl;
+import com.itasocialacademy.oitassist.user.dao.dto.request.ChangeUserRoleRequest;
 import com.itasocialacademy.oitassist.user.dao.dto.request.CreateUserDTO;
 import com.itasocialacademy.oitassist.user.dao.dto.request.UpdateUserDTO;
 import com.itasocialacademy.oitassist.user.dao.dto.response.ResponseUserDTO;
@@ -11,10 +12,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @Tag(name = "Users v1", description = "Operations related to users")
@@ -49,5 +50,54 @@ public class UserController
     })
     public ResponseEntity<ResponseUserDTO> getProfile() {
         return ResponseEntity.ok(service.getCurrentUserProfile());
+    }
+
+    @PatchMapping("/{id}/role")
+    @Operation(
+        summary = "Change user role",
+        description = "Allows admin to change role of an existing user")
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "User role updated successfully",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ResponseUserDTO.class))),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Invalid role or request payload",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(example = """
+                        {
+                            "message": "Invalid role provided"
+                        }
+                    """))),
+        @ApiResponse(
+            responseCode = "403",
+            description = "Forbidden - insufficient permissions or attempt to modify restricted user",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(example = """
+                        {
+                            "message": "Access denied"
+                        }
+                    """))),
+        @ApiResponse(
+            responseCode = "404",
+            description = "User not found",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(example = """
+                        {
+                            "message": "User not found"
+                        }
+                    """)))
+    })
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ResponseUserDTO> changeUserRole(
+        @PathVariable Long id,
+        @RequestBody @Valid ChangeUserRoleRequest request) {
+        return ResponseEntity.ok(service.changeUserRole(id, request.getRole()));
     }
 }

--- a/src/main/java/com/itasocialacademy/oitassist/user/dao/dto/request/ChangeUserRoleRequest.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/dao/dto/request/ChangeUserRoleRequest.java
@@ -1,0 +1,18 @@
+package com.itasocialacademy.oitassist.user.dao.dto.request;
+
+import com.itasocialacademy.oitassist.user.dao.enums.Role;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Request object for changing user role")
+public class ChangeUserRoleRequest {
+    @Schema(description = "New role to assign to the user", example = "USER")
+    @NotNull
+    private Role role;
+}

--- a/src/main/java/com/itasocialacademy/oitassist/user/exceptions/AdminRoleModificationException.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/exceptions/AdminRoleModificationException.java
@@ -1,0 +1,10 @@
+package com.itasocialacademy.oitassist.user.exceptions;
+
+import com.itasocialacademy.oitassist.core.enums.ErrorCode;
+import com.itasocialacademy.oitassist.core.exceptions.BusinessException;
+
+public class AdminRoleModificationException extends BusinessException {
+    public AdminRoleModificationException() {
+        super("Cannot modify role of another administrator", ErrorCode.ADMIN_ROLE_MODIFICATION_RESTRICTED);
+    }
+}

--- a/src/main/java/com/itasocialacademy/oitassist/user/exceptions/UserRoleSelfChangeException.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/exceptions/UserRoleSelfChangeException.java
@@ -1,0 +1,10 @@
+package com.itasocialacademy.oitassist.user.exceptions;
+
+import com.itasocialacademy.oitassist.core.enums.ErrorCode;
+import com.itasocialacademy.oitassist.core.exceptions.BusinessException;
+
+public class UserRoleSelfChangeException extends BusinessException {
+    public UserRoleSelfChangeException() {
+        super("User cannot change their own role", ErrorCode.USER_ROLE_SELF_CHANGE);
+    }
+}

--- a/src/main/java/com/itasocialacademy/oitassist/user/service/UserServiceImpl.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/service/UserServiceImpl.java
@@ -2,6 +2,7 @@ package com.itasocialacademy.oitassist.user.service;
 
 import com.itasocialacademy.oitassist.core.enums.ErrorCode;
 import com.itasocialacademy.oitassist.core.exceptions.AuthorizationException;
+import com.itasocialacademy.oitassist.core.exceptions.InsufficientPermissionsException;
 import com.itasocialacademy.oitassist.core.rest.service.AbstractServiceImpl;
 import com.itasocialacademy.oitassist.security.api.dto.UserDetailsImpl;
 import com.itasocialacademy.oitassist.security.api.interfaces.SecurityFacade;
@@ -77,6 +78,9 @@ public class UserServiceImpl
             .orElseThrow(() -> new AuthorizationException("User is not authenticated", ErrorCode.ACCESS_DENIED))
             .equals(userId)) {
             throw new UserRoleSelfChangeException();
+        }
+        if (!securityFacade.hasRole(String.valueOf(Role.ADMIN))) {
+            throw new InsufficientPermissionsException();
         }
         User user = repository.findById(userId)
             .orElseThrow(UserNotFoundException::new);

--- a/src/main/java/com/itasocialacademy/oitassist/user/service/UserServiceImpl.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/service/UserServiceImpl.java
@@ -9,11 +9,14 @@ import com.itasocialacademy.oitassist.user.api.dto.UserAuthDetails;
 import com.itasocialacademy.oitassist.user.dao.dto.request.CreateUserDTO;
 import com.itasocialacademy.oitassist.user.dao.dto.request.UpdateUserDTO;
 import com.itasocialacademy.oitassist.user.dao.dto.response.ResponseUserDTO;
+import com.itasocialacademy.oitassist.user.dao.enums.Role;
 import com.itasocialacademy.oitassist.user.dao.model.User;
+import com.itasocialacademy.oitassist.user.exceptions.AdminRoleModificationException;
+import com.itasocialacademy.oitassist.user.exceptions.UserNotFoundException;
+import com.itasocialacademy.oitassist.user.exceptions.UserRoleSelfChangeException;
 import com.itasocialacademy.oitassist.user.mapper.UserMapper;
 import com.itasocialacademy.oitassist.user.dao.repository.UserRepository;
 import com.itasocialacademy.oitassist.user.service.interfaces.UserService;
-import jakarta.persistence.EntityNotFoundException;
 import org.jspecify.annotations.NonNull;
 import org.springframework.stereotype.Service;
 import java.util.Optional;
@@ -55,7 +58,7 @@ public class UserServiceImpl
         Optional<User> user = repository.findUserByEmail(email);
 
         return user.map(mapper::toResponseUserDTO)
-            .orElseThrow(() -> new EntityNotFoundException("User not found: " + email));
+            .orElseThrow(UserNotFoundException::new);
     }
 
     @Override
@@ -65,5 +68,22 @@ public class UserServiceImpl
             .orElseThrow(() -> new AuthorizationException("User is not authenticated", ErrorCode.ACCESS_DENIED));
 
         return loadUserByEmail(email);
+    }
+
+    @Override
+    @NonNull
+    public ResponseUserDTO changeUserRole(@NonNull Long userId, @NonNull Role newRole) {
+        if (securityFacade.getCurrentUserId()
+            .orElseThrow(() -> new AuthorizationException("User is not authenticated", ErrorCode.ACCESS_DENIED))
+            .equals(userId)) {
+            throw new UserRoleSelfChangeException();
+        }
+        User user = repository.findById(userId)
+            .orElseThrow(UserNotFoundException::new);
+        if (user.getRole().equals(Role.ADMIN)) {
+            throw new AdminRoleModificationException();
+        }
+        user.setRole(newRole);
+        return mapper.toResponseUserDTO(repository.save(user));
     }
 }

--- a/src/main/java/com/itasocialacademy/oitassist/user/service/interfaces/UserService.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/service/interfaces/UserService.java
@@ -1,6 +1,7 @@
 package com.itasocialacademy.oitassist.user.service.interfaces;
 
 import com.itasocialacademy.oitassist.core.exceptions.AuthorizationException;
+import com.itasocialacademy.oitassist.core.exceptions.InsufficientPermissionsException;
 import com.itasocialacademy.oitassist.core.rest.service.interfaces.BaseService;
 import com.itasocialacademy.oitassist.security.api.dto.UserDetailsImpl;
 import com.itasocialacademy.oitassist.user.api.dto.UserAuthDetails;
@@ -54,12 +55,13 @@ public interface UserService extends BaseService<Long, CreateUserDTO, UpdateUser
      * @param userId  target user identifier
      * @param newRole new role to assign
      * @return updated user profile
-     * @throws AuthorizationException         if user is not authenticated
-     * @throws UserNotFoundException          if user with given id does not exist
-     * @throws UserRoleSelfChangeException    if user is trying to change his own
-     *                                        role
-     * @throws AdminRoleModificationException if user is trying to change the role
-     *                                        of another Admin
+     * @throws AuthorizationException           if user is not authenticated
+     * @throws UserNotFoundException            if user with given id does not exist
+     * @throws UserRoleSelfChangeException      if user is trying to change his own
+     *                                          role
+     * @throws AdminRoleModificationException   if user is trying to change the role
+     *                                          of another Admin
+     * @throws InsufficientPermissionsException if user does not have admin role
      */
     @NonNull
     ResponseUserDTO changeUserRole(@NonNull Long userId, @NonNull Role newRole);

--- a/src/main/java/com/itasocialacademy/oitassist/user/service/interfaces/UserService.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/service/interfaces/UserService.java
@@ -54,11 +54,12 @@ public interface UserService extends BaseService<Long, CreateUserDTO, UpdateUser
      * @param userId  target user identifier
      * @param newRole new role to assign
      * @return updated user profile
-     *
-     * @throws AuthorizationException if user is not authenticated
-     * @throws UserNotFoundException if user with given id does not exist
-     * @throws UserRoleSelfChangeException if user is trying to change his own role
-     * @throws AdminRoleModificationException if user is trying to change the role of another Admin
+     * @throws AuthorizationException         if user is not authenticated
+     * @throws UserNotFoundException          if user with given id does not exist
+     * @throws UserRoleSelfChangeException    if user is trying to change his own
+     *                                        role
+     * @throws AdminRoleModificationException if user is trying to change the role
+     *                                        of another Admin
      */
     @NonNull
     ResponseUserDTO changeUserRole(@NonNull Long userId, @NonNull Role newRole);

--- a/src/main/java/com/itasocialacademy/oitassist/user/service/interfaces/UserService.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/service/interfaces/UserService.java
@@ -1,12 +1,16 @@
 package com.itasocialacademy.oitassist.user.service.interfaces;
 
+import com.itasocialacademy.oitassist.core.exceptions.AuthorizationException;
 import com.itasocialacademy.oitassist.core.rest.service.interfaces.BaseService;
 import com.itasocialacademy.oitassist.security.api.dto.UserDetailsImpl;
 import com.itasocialacademy.oitassist.user.api.dto.UserAuthDetails;
 import com.itasocialacademy.oitassist.user.dao.dto.request.CreateUserDTO;
 import com.itasocialacademy.oitassist.user.dao.dto.request.UpdateUserDTO;
 import com.itasocialacademy.oitassist.user.dao.dto.response.ResponseUserDTO;
-import jakarta.persistence.EntityNotFoundException;
+import com.itasocialacademy.oitassist.user.dao.enums.Role;
+import com.itasocialacademy.oitassist.user.exceptions.AdminRoleModificationException;
+import com.itasocialacademy.oitassist.user.exceptions.UserNotFoundException;
+import com.itasocialacademy.oitassist.user.exceptions.UserRoleSelfChangeException;
 import java.util.Optional;
 import org.jspecify.annotations.NonNull;
 
@@ -30,7 +34,7 @@ public interface UserService extends BaseService<Long, CreateUserDTO, UpdateUser
      *
      * @param email the user's email address
      * @return the user's profile DTO
-     * @throws EntityNotFoundException if no user found with given email
+     * @throws UserNotFoundException if no user found with given email
      */
     @NonNull
     ResponseUserDTO loadUserByEmail(String email);
@@ -39,8 +43,23 @@ public interface UserService extends BaseService<Long, CreateUserDTO, UpdateUser
      * Finds a current authenticated user and returns their profile.
      *
      * @return the user's profile DTO
-     * @throws EntityNotFoundException if no user found with given email
+     * @throws AuthorizationException if user is not authenticated
      */
     @NonNull
     ResponseUserDTO getCurrentUserProfile();
+
+    /**
+     * Changes the role of an existing user.
+     *
+     * @param userId  target user identifier
+     * @param newRole new role to assign
+     * @return updated user profile
+     *
+     * @throws AuthorizationException if user is not authenticated
+     * @throws UserNotFoundException if user with given id does not exist
+     * @throws UserRoleSelfChangeException if user is trying to change his own role
+     * @throws AdminRoleModificationException if user is trying to change the role of another Admin
+     */
+    @NonNull
+    ResponseUserDTO changeUserRole(@NonNull Long userId, @NonNull Role newRole);
 }

--- a/src/test/java/com/itasocialacademy/oitassist/users/controller/UsersControllerTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/users/controller/UsersControllerTest.java
@@ -51,8 +51,8 @@ class UsersControllerTest extends ControllerUnitTest<UserController> {
         when(userService.getCurrentUserProfile()).thenReturn(profile);
 
         mockMvc.perform(
-                get("/api/v1/users/profile")
-                    .contentType(MediaType.APPLICATION_JSON))
+            get("/api/v1/users/profile")
+                .contentType(MediaType.APPLICATION_JSON))
             // then
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.id").value(1L))
@@ -83,8 +83,8 @@ class UsersControllerTest extends ControllerUnitTest<UserController> {
             .thenReturn(response);
 
         mockMvc.perform(patch("/api/v1/users/{id}/role", userId)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.id").value(userId))
             .andExpect(jsonPath("$.role").value("ORG"));
@@ -97,8 +97,8 @@ class UsersControllerTest extends ControllerUnitTest<UserController> {
     void changeUserRole_ShouldReturnBadRequest_WhenRequestIsInvalid() throws Exception {
 
         mockMvc.perform(patch("/api/v1/users/{id}/role", 1L)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{}"))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{}"))
             .andExpect(status().isBadRequest());
 
         verifyNoInteractions(userService);

--- a/src/test/java/com/itasocialacademy/oitassist/users/controller/UsersControllerTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/users/controller/UsersControllerTest.java
@@ -2,6 +2,7 @@ package com.itasocialacademy.oitassist.users.controller;
 
 import com.itasocialacademy.oitassist.ControllerUnitTest;
 import com.itasocialacademy.oitassist.user.controller.UserController;
+import com.itasocialacademy.oitassist.user.dao.dto.request.ChangeUserRoleRequest;
 import com.itasocialacademy.oitassist.user.dao.dto.response.ResponseUserDTO;
 import com.itasocialacademy.oitassist.user.dao.enums.Role;
 import com.itasocialacademy.oitassist.user.dao.enums.UserStatus;
@@ -14,6 +15,7 @@ import org.springframework.http.MediaType;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -49,8 +51,8 @@ class UsersControllerTest extends ControllerUnitTest<UserController> {
         when(userService.getCurrentUserProfile()).thenReturn(profile);
 
         mockMvc.perform(
-            get("/api/v1/users/profile")
-                .contentType(MediaType.APPLICATION_JSON))
+                get("/api/v1/users/profile")
+                    .contentType(MediaType.APPLICATION_JSON))
             // then
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.id").value(1L))
@@ -63,4 +65,42 @@ class UsersControllerTest extends ControllerUnitTest<UserController> {
         verify(userService, times(1)).getCurrentUserProfile();
     }
 
+    @Test
+    @DisplayName("changeUserRole should return updated user when request is valid")
+    void changeUserRole_ShouldReturnUpdatedUser_WhenRequestIsValid() throws Exception {
+        Long userId = 1L;
+
+        ChangeUserRoleRequest request = ChangeUserRoleRequest.builder()
+            .role(Role.ORG)
+            .build();
+
+        ResponseUserDTO response = ResponseUserDTO.builder()
+            .id(userId)
+            .role(Role.ORG)
+            .build();
+
+        when(userService.changeUserRole(userId, Role.ORG))
+            .thenReturn(response);
+
+        mockMvc.perform(patch("/api/v1/users/{id}/role", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(userId))
+            .andExpect(jsonPath("$.role").value("ORG"));
+
+        verify(userService).changeUserRole(userId, Role.ORG);
+    }
+
+    @Test
+    @DisplayName("changeUserRole should return bad request when request body is invalid")
+    void changeUserRole_ShouldReturnBadRequest_WhenRequestIsInvalid() throws Exception {
+
+        mockMvc.perform(patch("/api/v1/users/{id}/role", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+            .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(userService);
+    }
 }

--- a/src/test/java/com/itasocialacademy/oitassist/users/service/UserServiceImplTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/users/service/UserServiceImplTest.java
@@ -7,6 +7,9 @@ import com.itasocialacademy.oitassist.user.dao.enums.Role;
 import com.itasocialacademy.oitassist.user.dao.enums.UserStatus;
 import com.itasocialacademy.oitassist.user.dao.model.User;
 import com.itasocialacademy.oitassist.user.dao.repository.UserRepository;
+import com.itasocialacademy.oitassist.user.exceptions.AdminRoleModificationException;
+import com.itasocialacademy.oitassist.user.exceptions.UserNotFoundException;
+import com.itasocialacademy.oitassist.user.exceptions.UserRoleSelfChangeException;
 import com.itasocialacademy.oitassist.user.mapper.UserMapper;
 import com.itasocialacademy.oitassist.user.service.UserServiceImpl;
 import jakarta.persistence.EntityNotFoundException;
@@ -66,14 +69,14 @@ class UserServiceImplTest {
 
     @Test
     @DisplayName("loadUserByEmail should throw EntityNotFoundException when user not found")
-    void loadUserByEmail_ShouldThrowEntityNotFoundException_WhenUserNotFound() {
+    void loadUserByEmail_ShouldThrowUserNotFoundException_WhenUserNotFound() {
         String email = "test@email.com";
 
         when(repository.findUserByEmail(email)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> userService.loadUserByEmail(email))
-            .isInstanceOf(EntityNotFoundException.class)
-            .hasMessageContaining("User not found: " + email);
+            .isInstanceOf(UserNotFoundException.class)
+            .hasMessageContaining("User not found");
 
         verify(repository, times(1)).findUserByEmail(email);
         verifyNoInteractions(mapper);
@@ -126,6 +129,110 @@ class UserServiceImplTest {
             .hasMessage("User is not authenticated");
 
         verify(securityFacade, times(1)).getCurrentUserEmail();
+        verifyNoInteractions(repository, mapper);
+    }
+
+    @Test
+    @DisplayName("changeUserRole should update user role when request is valid")
+    void changeUserRole_ShouldUpdateUserRole_WhenRequestIsValid() {
+        Long currentUserId = 1L;
+        Long targetUserId = 2L;
+
+        User user = User.builder()
+            .id(targetUserId)
+            .role(Role.USER)
+            .build();
+
+        ResponseUserDTO expected = ResponseUserDTO.builder()
+            .id(targetUserId)
+            .role(Role.ORG)
+            .build();
+
+        when(securityFacade.getCurrentUserId()).thenReturn(Optional.of(currentUserId));
+        when(repository.findById(targetUserId)).thenReturn(Optional.of(user));
+        when(repository.save(user)).thenReturn(user);
+        when(mapper.toResponseUserDTO(user)).thenReturn(expected);
+
+        ResponseUserDTO result = userService.changeUserRole(targetUserId, Role.ORG);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getRole()).isEqualTo(Role.ORG);
+        assertThat(user.getRole()).isEqualTo(Role.ORG);
+
+        verify(securityFacade).getCurrentUserId();
+        verify(repository).findById(targetUserId);
+        verify(repository).save(user);
+        verify(mapper).toResponseUserDTO(user);
+    }
+
+    @Test
+    @DisplayName("changeUserRole should throw UserRoleSelfChangeException when user tries to change own role")
+    void changeUserRole_ShouldThrowUserRoleSelfChangeException_WhenChangingOwnRole() {
+        Long currentUserId = 1L;
+
+        when(securityFacade.getCurrentUserId()).thenReturn(Optional.of(currentUserId));
+
+        assertThatThrownBy(() -> userService.changeUserRole(currentUserId, Role.USER))
+            .isInstanceOf(UserRoleSelfChangeException.class)
+            .hasMessage("User cannot change their own role");
+
+        verify(securityFacade).getCurrentUserId();
+        verifyNoInteractions(repository, mapper);
+    }
+
+    @Test
+    @DisplayName("changeUserRole should throw UserNotFoundException when target user does not exist")
+    void changeUserRole_ShouldThrowUserNotFoundException_WhenUserNotFound() {
+        Long currentUserId = 1L;
+        Long targetUserId = 2L;
+
+        when(securityFacade.getCurrentUserId()).thenReturn(Optional.of(currentUserId));
+        when(repository.findById(targetUserId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userService.changeUserRole(targetUserId, Role.ORG))
+            .isInstanceOf(UserNotFoundException.class)
+            .hasMessage("User not found");
+
+        verify(securityFacade).getCurrentUserId();
+        verify(repository).findById(targetUserId);
+        verifyNoMoreInteractions(repository);
+        verifyNoInteractions(mapper);
+    }
+
+    @Test
+    @DisplayName("changeUserRole should throw AdminRoleModificationException when target user is admin")
+    void changeUserRole_ShouldThrowAdminRoleModificationException_WhenTargetUserIsAdmin() {
+        Long currentUserId = 1L;
+        Long targetUserId = 2L;
+
+        User admin = User.builder()
+            .id(targetUserId)
+            .role(Role.ADMIN)
+            .build();
+
+        when(securityFacade.getCurrentUserId()).thenReturn(Optional.of(currentUserId));
+        when(repository.findById(targetUserId)).thenReturn(Optional.of(admin));
+
+        assertThatThrownBy(() -> userService.changeUserRole(targetUserId, Role.USER))
+            .isInstanceOf(AdminRoleModificationException.class)
+            .hasMessage("Cannot modify role of another administrator");
+
+        verify(securityFacade).getCurrentUserId();
+        verify(repository).findById(targetUserId);
+        verify(repository, never()).save(any());
+        verifyNoInteractions(mapper);
+    }
+
+    @Test
+    @DisplayName("changeUserRole should throw AuthorizationException when user is not authenticated")
+    void changeUserRole_ShouldThrowAuthorizationException_WhenUserIsNotAuthenticated() {
+        when(securityFacade.getCurrentUserId()).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userService.changeUserRole(1L, Role.USER))
+            .isInstanceOf(AuthorizationException.class)
+            .hasMessage("User is not authenticated");
+
+        verify(securityFacade).getCurrentUserId();
         verifyNoInteractions(repository, mapper);
     }
 }

--- a/src/test/java/com/itasocialacademy/oitassist/users/service/UserServiceImplTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/users/service/UserServiceImplTest.java
@@ -12,7 +12,6 @@ import com.itasocialacademy.oitassist.user.exceptions.UserNotFoundException;
 import com.itasocialacademy.oitassist.user.exceptions.UserRoleSelfChangeException;
 import com.itasocialacademy.oitassist.user.mapper.UserMapper;
 import com.itasocialacademy.oitassist.user.service.UserServiceImpl;
-import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/com/itasocialacademy/oitassist/users/service/UserServiceImplTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/users/service/UserServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.itasocialacademy.oitassist.users.service;
 
 import com.itasocialacademy.oitassist.core.exceptions.AuthorizationException;
+import com.itasocialacademy.oitassist.core.exceptions.InsufficientPermissionsException;
 import com.itasocialacademy.oitassist.security.api.interfaces.SecurityFacade;
 import com.itasocialacademy.oitassist.user.dao.dto.response.ResponseUserDTO;
 import com.itasocialacademy.oitassist.user.dao.enums.Role;
@@ -132,8 +133,8 @@ class UserServiceImplTest {
     }
 
     @Test
-    @DisplayName("changeUserRole should update user role when request is valid")
-    void changeUserRole_ShouldUpdateUserRole_WhenRequestIsValid() {
+    @DisplayName("changeUserRole should update user role when user is admin and request is valid")
+    void changeUserRole_ShouldUpdatedUserRole_WhenUserIsAdminAndRequestIsValid() {
         Long currentUserId = 1L;
         Long targetUserId = 2L;
 
@@ -147,6 +148,7 @@ class UserServiceImplTest {
             .role(Role.ORG)
             .build();
 
+        when(securityFacade.hasRole(String.valueOf(Role.ADMIN))).thenReturn(true);
         when(securityFacade.getCurrentUserId()).thenReturn(Optional.of(currentUserId));
         when(repository.findById(targetUserId)).thenReturn(Optional.of(user));
         when(repository.save(user)).thenReturn(user);
@@ -158,6 +160,7 @@ class UserServiceImplTest {
         assertThat(result.getRole()).isEqualTo(Role.ORG);
         assertThat(user.getRole()).isEqualTo(Role.ORG);
 
+        verify(securityFacade).hasRole(String.valueOf(Role.ADMIN));
         verify(securityFacade).getCurrentUserId();
         verify(repository).findById(targetUserId);
         verify(repository).save(user);
@@ -185,6 +188,7 @@ class UserServiceImplTest {
         Long currentUserId = 1L;
         Long targetUserId = 2L;
 
+        when(securityFacade.hasRole(String.valueOf(Role.ADMIN))).thenReturn(true);
         when(securityFacade.getCurrentUserId()).thenReturn(Optional.of(currentUserId));
         when(repository.findById(targetUserId)).thenReturn(Optional.empty());
 
@@ -192,6 +196,7 @@ class UserServiceImplTest {
             .isInstanceOf(UserNotFoundException.class)
             .hasMessage("User not found");
 
+        verify(securityFacade).hasRole(String.valueOf(Role.ADMIN));
         verify(securityFacade).getCurrentUserId();
         verify(repository).findById(targetUserId);
         verifyNoMoreInteractions(repository);
@@ -209,6 +214,7 @@ class UserServiceImplTest {
             .role(Role.ADMIN)
             .build();
 
+        when(securityFacade.hasRole(String.valueOf(Role.ADMIN))).thenReturn(true);
         when(securityFacade.getCurrentUserId()).thenReturn(Optional.of(currentUserId));
         when(repository.findById(targetUserId)).thenReturn(Optional.of(admin));
 
@@ -216,6 +222,7 @@ class UserServiceImplTest {
             .isInstanceOf(AdminRoleModificationException.class)
             .hasMessage("Cannot modify role of another administrator");
 
+        verify(securityFacade).hasRole(String.valueOf(Role.ADMIN));
         verify(securityFacade).getCurrentUserId();
         verify(repository).findById(targetUserId);
         verify(repository, never()).save(any());
@@ -231,6 +238,24 @@ class UserServiceImplTest {
             .isInstanceOf(AuthorizationException.class)
             .hasMessage("User is not authenticated");
 
+        verify(securityFacade).getCurrentUserId();
+        verifyNoInteractions(repository, mapper);
+    }
+
+    @Test
+    @DisplayName("changeUserRole should throw InsufficientPermissionsException when user is not admin")
+    void changeUserRole_ShouldThrowInsufficientPermissionsException_WhenUserIsNotAdmin() {
+        Long currentUserId = 1L;
+        Long targetUserId = 2L;
+
+        when(securityFacade.hasRole(String.valueOf(Role.ADMIN))).thenReturn(false);
+        when(securityFacade.getCurrentUserId()).thenReturn(Optional.of(currentUserId));
+
+        assertThatThrownBy(() -> userService.changeUserRole(targetUserId, Role.ORG))
+            .isInstanceOf(InsufficientPermissionsException.class)
+            .hasMessage("You do not have enough permissions to perform this action");
+
+        verify(securityFacade).hasRole(String.valueOf(Role.ADMIN));
         verify(securityFacade).getCurrentUserId();
         verifyNoInteractions(repository, mapper);
     }


### PR DESCRIPTION
# OitAssist PR
## Issue Link 📋
<a href="https://github.com/ita-social-projects/oitAssist/issues/285">#285</a>

## Changed
Implemented user role management endpoint for admin users
Added business rules for role change restrictions (self-role change and admin protection)
Added unit tests for service layer role change logic
Added controller tests for role management API endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin-only `PATCH /api/v1/users/{id}/role` endpoint to update user roles, including a validated role-change request.
* **Bug Fixes**
  * Enforced security rules to block self role changes, prevent modifying admin roles, and return clearer authorization and user-not-found errors.
* **Tests**
  * Expanded controller and service tests to cover successful updates, invalid requests (400), and authorization/edge-case failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->