### PR TITLE
Fix/Restrict login to active users only

### DIFF
--- a/src/main/java/com/itasocialacademy/oitassist/security/api/dto/UserDetailsImpl.java
+++ b/src/main/java/com/itasocialacademy/oitassist/security/api/dto/UserDetailsImpl.java
@@ -22,12 +22,15 @@ public class UserDetailsImpl implements UserDetails {
     private final Long id;
     private final String email;
     private final String password;
+    private final boolean enabled;
     private final Collection<? extends GrantedAuthority> authorities;
 
-    public UserDetailsImpl(Long id, String email, String password, Collection<? extends GrantedAuthority> authorities) {
+    public UserDetailsImpl(Long id, String email, String password, boolean enabled,
+        Collection<? extends GrantedAuthority> authorities) {
         this.id = id;
         this.email = email;
         this.password = password;
+        this.enabled = enabled;
         this.authorities =
             authorities != null ? Collections.unmodifiableCollection(authorities) : Collections.emptyList();
     }
@@ -64,7 +67,7 @@ public class UserDetailsImpl implements UserDetails {
 
     @Override
     public boolean isEnabled() {
-        return true;
+        return enabled;
     }
 
     @Override

--- a/src/main/java/com/itasocialacademy/oitassist/security/service/TokenServiceImpl.java
+++ b/src/main/java/com/itasocialacademy/oitassist/security/service/TokenServiceImpl.java
@@ -13,6 +13,7 @@ import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.SignatureException;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -45,6 +46,8 @@ public class TokenServiceImpl implements TokenService {
                 .getPrincipal();
         } catch (BadCredentialsException e) {
             throw new AuthenticationException("Bad credentials", ErrorCode.BAD_CREDENTIAL);
+        } catch (DisabledException e) {
+            throw new AuthenticationException("Account is not activated", ErrorCode.USER_NOT_ACTIVATED);
         }
 
         return getTokenResponse(Objects.requireNonNull(userDetails));

--- a/src/main/java/com/itasocialacademy/oitassist/user/service/SecurityUserProviderImpl.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/service/SecurityUserProviderImpl.java
@@ -2,6 +2,7 @@ package com.itasocialacademy.oitassist.user.service;
 
 import com.itasocialacademy.oitassist.security.api.interfaces.SecurityUserProvider;
 import com.itasocialacademy.oitassist.security.api.dto.UserDetailsImpl;
+import com.itasocialacademy.oitassist.user.dao.enums.UserStatus;
 import com.itasocialacademy.oitassist.user.dao.model.User;
 import com.itasocialacademy.oitassist.user.dao.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -58,6 +59,7 @@ public class SecurityUserProviderImpl implements SecurityUserProvider {
             .id(user.getId())
             .email(user.getEmail())
             .password(user.getPassword())
+            .enabled(user.getUserStatus() == UserStatus.ACTIVE)
             .authorities(List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name())))
             .build();
     }


### PR DESCRIPTION
# OitAssist PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sign-in now correctly respects whether an account is active or disabled.
  * Users with inactive accounts are prevented from generating tokens and receive a clear activation-related error.
  * Account status is now reflected properly during authentication checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->