### PR TITLE
[Feature] Implement get users API endpoint for admins with optional search

### DIFF
--- a/src/main/java/com/itasocialacademy/oitassist/user/controller/UserController.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.itasocialacademy.oitassist.user.controller;
 import static org.springframework.data.domain.Sort.Direction.DESC;
 import com.itasocialacademy.oitassist.core.dao.dto.response.PageResponse;
 import com.itasocialacademy.oitassist.core.rest.controller.AbstractRestControllerImpl;
+import com.itasocialacademy.oitassist.core.web.ErrorResponse;
 import com.itasocialacademy.oitassist.user.dao.dto.request.ChangeUserRoleRequest;
 import com.itasocialacademy.oitassist.user.dao.dto.request.CreateUserDTO;
 import com.itasocialacademy.oitassist.user.dao.dto.request.UpdateUserDTO;
@@ -48,11 +49,7 @@ public class UserController
             description = "Unauthorized - token is missing or invalid",
             content = @Content(
                 mediaType = "application/json",
-                schema = @Schema(example = """
-                        {
-                            "message": "Full authentication is required to access this resource"
-                        }
-                    """)))
+                schema = @Schema(implementation = ErrorResponse.class)))
     })
     public ResponseEntity<ResponseUserDTO> getProfile() {
         return ResponseEntity.ok(service.getCurrentUserProfile());
@@ -74,41 +71,25 @@ public class UserController
             description = "Invalid role or request payload",
             content = @Content(
                 mediaType = "application/json",
-                schema = @Schema(example = """
-                        {
-                            "message": "Invalid role provided"
-                        }
-                    """))),
+                schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(
             responseCode = "401",
             description = "Unauthorized - token is missing or invalid",
             content = @Content(
                 mediaType = "application/json",
-                schema = @Schema(example = """
-                        {
-                            "message": "Full authentication is required to access this resource"
-                        }
-                    """))),
+                schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(
             responseCode = "403",
             description = "Forbidden - insufficient permissions or attempt to modify restricted user",
             content = @Content(
                 mediaType = "application/json",
-                schema = @Schema(example = """
-                        {
-                            "message": "Access denied"
-                        }
-                    """))),
+                schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(
             responseCode = "404",
             description = "User not found",
             content = @Content(
                 mediaType = "application/json",
-                schema = @Schema(example = """
-                        {
-                            "message": "User not found"
-                        }
-                    """)))
+                schema = @Schema(implementation = ErrorResponse.class)))
     })
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ResponseUserDTO> changeUserRole(
@@ -129,21 +110,13 @@ public class UserController
             description = "Unauthorized - token is missing or invalid",
             content = @Content(
                 mediaType = "application/json",
-                schema = @Schema(example = """
-                        {
-                            "message": "Full authentication is required to access this resource"
-                        }
-                    """))),
+                schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(
             responseCode = "403",
             description = "Forbidden - insufficient permissions",
             content = @Content(
                 mediaType = "application/json",
-                schema = @Schema(example = """
-                        {
-                            "message": "You do not have enough permissions to perform this action"
-                        }
-                    """)))
+                schema = @Schema(implementation = ErrorResponse.class)))
     })
     @GetMapping
     @PreAuthorize("hasRole('ADMIN')")

--- a/src/main/java/com/itasocialacademy/oitassist/user/controller/UserController.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.itasocialacademy.oitassist.user.controller;
 
+import static org.springframework.data.domain.Sort.Direction.DESC;
 import com.itasocialacademy.oitassist.core.dao.dto.response.PageResponse;
 import com.itasocialacademy.oitassist.core.rest.controller.AbstractRestControllerImpl;
 import com.itasocialacademy.oitassist.user.dao.dto.request.ChangeUserRoleRequest;
@@ -9,6 +10,7 @@ import com.itasocialacademy.oitassist.user.dao.dto.response.ResponseUserDTO;
 import com.itasocialacademy.oitassist.user.service.interfaces.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -16,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -114,8 +117,6 @@ public class UserController
         return ResponseEntity.ok(service.changeUserRole(id, request.getRole()));
     }
 
-    @GetMapping
-    @PreAuthorize("hasRole('ADMIN')")
     @Operation(
         summary = "Get paginated list of users",
         description = "Returns a paginated list of users for the admin dashboard with optional search by name or email")
@@ -144,15 +145,22 @@ public class UserController
                         }
                     """)))
     })
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    @Parameters({
+        @Parameter(name = "page", description = "Zero-based page index", example = "0"),
+        @Parameter(name = "size", description = "Page size", example = "5"),
+        @Parameter(name = "sort", description = "Sorting criteria", example = "firstName,desc")
+    })
     public ResponseEntity<PageResponse<ResponseUserDTO>> getUsers(
-        @Parameter(description = "Pagination parameters")
-        Pageable pageable,
+        @Parameter(hidden = true) @PageableDefault(
+            size = 5,
+            sort = "id",
+            direction = DESC) Pageable pageable,
 
         @Parameter(
             description = "Optional search query for filtering users by name or email",
-            example = "ivan")
-        @RequestParam(required = false) String search
-    ) {
+            example = "ivan") @RequestParam(required = false) String search) {
         return ResponseEntity.ok(PageResponse.from(service.getUsers(pageable, search)));
     }
 }

--- a/src/main/java/com/itasocialacademy/oitassist/user/controller/UserController.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/controller/UserController.java
@@ -15,7 +15,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -130,20 +129,20 @@ public class UserController
             content = @Content(
                 mediaType = "application/json",
                 schema = @Schema(example = """
-                    {
-                        "message": "Full authentication is required to access this resource"
-                    }
-                """))),
+                        {
+                            "message": "Full authentication is required to access this resource"
+                        }
+                    """))),
         @ApiResponse(
             responseCode = "403",
             description = "Forbidden - insufficient permissions",
             content = @Content(
                 mediaType = "application/json",
                 schema = @Schema(example = """
-                    {
-                        "message": "Insufficient permissions to perform this action"
-                    }
-                """)))
+                        {
+                            "message": "Insufficient permissions to perform this action"
+                        }
+                    """)))
     })
     public ResponseEntity<PageResponse<ResponseUserDTO>> getUsers(
         @Parameter(description = "Pagination parameters")

--- a/src/main/java/com/itasocialacademy/oitassist/user/controller/UserController.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.itasocialacademy.oitassist.user.controller;
 
+import com.itasocialacademy.oitassist.core.dao.dto.response.PageResponse;
 import com.itasocialacademy.oitassist.core.rest.controller.AbstractRestControllerImpl;
 import com.itasocialacademy.oitassist.user.dao.dto.request.ChangeUserRoleRequest;
 import com.itasocialacademy.oitassist.user.dao.dto.request.CreateUserDTO;
@@ -7,12 +8,15 @@ import com.itasocialacademy.oitassist.user.dao.dto.request.UpdateUserDTO;
 import com.itasocialacademy.oitassist.user.dao.dto.response.ResponseUserDTO;
 import com.itasocialacademy.oitassist.user.service.interfaces.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -109,5 +113,47 @@ public class UserController
         @PathVariable Long id,
         @RequestBody @Valid ChangeUserRoleRequest request) {
         return ResponseEntity.ok(service.changeUserRole(id, request.getRole()));
+    }
+
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(
+        summary = "Get paginated list of users",
+        description = "Returns a paginated list of users for the admin dashboard with optional search by name or email")
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Users retrieved successfully"),
+        @ApiResponse(
+            responseCode = "401",
+            description = "Unauthorized - token is missing or invalid",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(example = """
+                    {
+                        "message": "Full authentication is required to access this resource"
+                    }
+                """))),
+        @ApiResponse(
+            responseCode = "403",
+            description = "Forbidden - insufficient permissions",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(example = """
+                    {
+                        "message": "Insufficient permissions to perform this action"
+                    }
+                """)))
+    })
+    public ResponseEntity<PageResponse<ResponseUserDTO>> getUsers(
+        @Parameter(description = "Pagination parameters")
+        Pageable pageable,
+
+        @Parameter(
+            description = "Optional search query for filtering users by name or email",
+            example = "ivan")
+        @RequestParam(required = false) String search
+    ) {
+        return ResponseEntity.ok(PageResponse.from(service.getUsers(pageable, search)));
     }
 }

--- a/src/main/java/com/itasocialacademy/oitassist/user/controller/UserController.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/controller/UserController.java
@@ -141,7 +141,7 @@ public class UserController
                 mediaType = "application/json",
                 schema = @Schema(example = """
                         {
-                            "message": "Insufficient permissions to perform this action"
+                            "message": "You do not have enough permissions to perform this action"
                         }
                     """)))
     })

--- a/src/main/java/com/itasocialacademy/oitassist/user/dao/dto/response/ResponseUserDTO.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/dao/dto/response/ResponseUserDTO.java
@@ -16,6 +16,7 @@ import lombok.*;
 @ToString
 @Schema(description = "User Response DTO")
 public class ResponseUserDTO implements EntityDTO<Long> {
+    @Schema(description = "User ID", example = "1")
     private Long id;
     @NotBlank
     @Schema(description = "User Email", example = "mail@gmail.com")

--- a/src/main/java/com/itasocialacademy/oitassist/user/dao/repository/UserRepository.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/dao/repository/UserRepository.java
@@ -22,8 +22,9 @@ public interface UserRepository extends EntityRepository<User, Long> {
                OR LOWER(u.surname) LIKE LOWER(CONCAT('%', :search, '%'))
                OR LOWER(u.middleName) LIKE LOWER(CONCAT('%', :search, '%'))
                OR LOWER(CONCAT(u.firstName, ' ', u.surname)) LIKE LOWER(CONCAT('%', :search, '%'))
-               OR LOWER(CONCAT(u.firstName, ' ', u.surname, ' ', u.middleName)) LIKE LOWER(CONCAT('%', :search, '%'))
                OR LOWER(CONCAT(u.surname, ' ', u.firstName)) LIKE LOWER(CONCAT('%', :search, '%'))
+               OR LOWER(CONCAT(u.firstName, ' ', u.middleName)) LIKE LOWER(CONCAT('%', :search, '%'))
+               OR LOWER(CONCAT(u.firstName, ' ', u.surname, ' ', u.middleName)) LIKE LOWER(CONCAT('%', :search, '%'))
                OR LOWER(CONCAT(u.surname, ' ', u.firstName, ' ', u.middleName)) LIKE LOWER(CONCAT('%', :search, '%'))
         """)
     Page<User> findAllBySearch(String search, Pageable pageable);

--- a/src/main/java/com/itasocialacademy/oitassist/user/dao/repository/UserRepository.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/dao/repository/UserRepository.java
@@ -17,15 +17,17 @@ public interface UserRepository extends EntityRepository<User, Long> {
     @Query("""
             SELECT u
             FROM User u
-            WHERE LOWER(u.email) LIKE LOWER(CONCAT('%', :search, '%'))
-               OR LOWER(u.firstName) LIKE LOWER(CONCAT('%', :search, '%'))
-               OR LOWER(u.surname) LIKE LOWER(CONCAT('%', :search, '%'))
-               OR LOWER(u.middleName) LIKE LOWER(CONCAT('%', :search, '%'))
-               OR LOWER(CONCAT(u.firstName, ' ', u.surname)) LIKE LOWER(CONCAT('%', :search, '%'))
-               OR LOWER(CONCAT(u.surname, ' ', u.firstName)) LIKE LOWER(CONCAT('%', :search, '%'))
-               OR LOWER(CONCAT(u.firstName, ' ', u.middleName)) LIKE LOWER(CONCAT('%', :search, '%'))
+            WHERE LOWER(u.email) LIKE LOWER(CONCAT('%', :search, '%')) ESCAPE '\\'
+               OR LOWER(u.firstName) LIKE LOWER(CONCAT('%', :search, '%')) ESCAPE '\\'
+               OR LOWER(u.surname) LIKE LOWER(CONCAT('%', :search, '%')) ESCAPE '\\'
+               OR LOWER(u.middleName) LIKE LOWER(CONCAT('%', :search, '%')) ESCAPE '\\'
+               OR LOWER(CONCAT(u.firstName, ' ', u.surname)) LIKE LOWER(CONCAT('%', :search, '%')) ESCAPE '\\'
+               OR LOWER(CONCAT(u.surname, ' ', u.firstName)) LIKE LOWER(CONCAT('%', :search, '%')) ESCAPE '\\'
+               OR LOWER(CONCAT(u.firstName, ' ', u.middleName)) LIKE LOWER(CONCAT('%', :search, '%')) ESCAPE '\\'
                OR LOWER(CONCAT(u.firstName, ' ', u.surname, ' ', u.middleName)) LIKE LOWER(CONCAT('%', :search, '%'))
+                       ESCAPE '\\'
                OR LOWER(CONCAT(u.surname, ' ', u.firstName, ' ', u.middleName)) LIKE LOWER(CONCAT('%', :search, '%'))
+                       ESCAPE '\\'
         """)
     Page<User> findAllBySearch(String search, Pageable pageable);
 }

--- a/src/main/java/com/itasocialacademy/oitassist/user/dao/repository/UserRepository.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/dao/repository/UserRepository.java
@@ -2,6 +2,9 @@ package com.itasocialacademy.oitassist.user.dao.repository;
 
 import com.itasocialacademy.oitassist.core.rest.repository.EntityRepository;
 import com.itasocialacademy.oitassist.user.dao.model.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.modulith.NamedInterface;
 import org.springframework.stereotype.Repository;
 import java.util.Optional;
@@ -10,4 +13,18 @@ import java.util.Optional;
 @NamedInterface("UserRepository")
 public interface UserRepository extends EntityRepository<User, Long> {
     Optional<User> findUserByEmail(String email);
+
+    @Query("""
+            SELECT u
+            FROM User u
+            WHERE LOWER(u.email) LIKE LOWER(CONCAT('%', :search, '%'))
+               OR LOWER(u.firstName) LIKE LOWER(CONCAT('%', :search, '%'))
+               OR LOWER(u.surname) LIKE LOWER(CONCAT('%', :search, '%'))
+               OR LOWER(u.middleName) LIKE LOWER(CONCAT('%', :search, '%'))
+               OR LOWER(CONCAT(u.firstName, ' ', u.surname)) LIKE LOWER(CONCAT('%', :search, '%'))
+               OR LOWER(CONCAT(u.firstName, ' ', u.surname, ' ', u.middleName)) LIKE LOWER(CONCAT('%', :search, '%'))
+               OR LOWER(CONCAT(u.surname, ' ', u.firstName)) LIKE LOWER(CONCAT('%', :search, '%'))
+               OR LOWER(CONCAT(u.surname, ' ', u.firstName, ' ', u.middleName)) LIKE LOWER(CONCAT('%', :search, '%'))
+        """)
+    Page<User> findAllBySearch(String search, Pageable pageable);
 }

--- a/src/main/java/com/itasocialacademy/oitassist/user/service/UserServiceImpl.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/service/UserServiceImpl.java
@@ -98,7 +98,15 @@ public class UserServiceImpl
         if (!securityFacade.hasRole(String.valueOf(Role.ADMIN))) {
             throw new InsufficientPermissionsException();
         }
-        String normalizedSearch = search == null ? "" : search.trim().replaceAll("\\s+", " ");
-        return repository.findAllBySearch(normalizedSearch, pageable).map(mapper::toResponseUserDTO);
+        if (search != null && !search.isBlank()) {
+            String normalizedSearch = search.trim()
+                .replaceAll("\\s+", " ")
+                .replace("\\", "\\\\")
+                .replace("%", "\\%")
+                .replace("_", "\\_");
+            return repository.findAllBySearch(normalizedSearch, pageable).map(mapper::toResponseUserDTO);
+        } else {
+            return repository.findAll(pageable).map(mapper::toResponseUserDTO);
+        }
     }
 }

--- a/src/main/java/com/itasocialacademy/oitassist/user/service/UserServiceImpl.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/service/UserServiceImpl.java
@@ -95,6 +95,9 @@ public class UserServiceImpl
 
     @Override
     public @NonNull Page<ResponseUserDTO> getUsers(@NonNull Pageable pageable, String search) {
+        if (!securityFacade.hasRole(String.valueOf(Role.ADMIN))) {
+            throw new InsufficientPermissionsException();
+        }
         String normalizedSearch = search == null ? "" : search.trim().replaceAll("\\s+", " ");
         return repository.findAllBySearch(normalizedSearch, pageable).map(mapper::toResponseUserDTO);
     }

--- a/src/main/java/com/itasocialacademy/oitassist/user/service/UserServiceImpl.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/service/UserServiceImpl.java
@@ -19,6 +19,8 @@ import com.itasocialacademy.oitassist.user.mapper.UserMapper;
 import com.itasocialacademy.oitassist.user.dao.repository.UserRepository;
 import com.itasocialacademy.oitassist.user.service.interfaces.UserService;
 import org.jspecify.annotations.NonNull;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import java.util.Optional;
 
@@ -89,5 +91,10 @@ public class UserServiceImpl
         }
         user.setRole(newRole);
         return mapper.toResponseUserDTO(repository.save(user));
+    }
+
+    @Override
+    public @NonNull Page<ResponseUserDTO> getUsers(@NonNull Pageable pageable, String search) {
+        return repository.findAllBySearch(search, pageable).map(mapper::toResponseUserDTO);
     }
 }

--- a/src/main/java/com/itasocialacademy/oitassist/user/service/UserServiceImpl.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/service/UserServiceImpl.java
@@ -95,6 +95,7 @@ public class UserServiceImpl
 
     @Override
     public @NonNull Page<ResponseUserDTO> getUsers(@NonNull Pageable pageable, String search) {
-        return repository.findAllBySearch(search, pageable).map(mapper::toResponseUserDTO);
+        String normalizedSearch = search == null ? "" : search.trim().replaceAll("\\s+", " ");
+        return repository.findAllBySearch(normalizedSearch, pageable).map(mapper::toResponseUserDTO);
     }
 }

--- a/src/main/java/com/itasocialacademy/oitassist/user/service/interfaces/UserService.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/service/interfaces/UserService.java
@@ -14,6 +14,8 @@ import com.itasocialacademy.oitassist.user.exceptions.UserNotFoundException;
 import com.itasocialacademy.oitassist.user.exceptions.UserRoleSelfChangeException;
 import java.util.Optional;
 import org.jspecify.annotations.NonNull;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface UserService extends BaseService<Long, CreateUserDTO, UpdateUserDTO, ResponseUserDTO> {
     /**
@@ -65,4 +67,15 @@ public interface UserService extends BaseService<Long, CreateUserDTO, UpdateUser
      */
     @NonNull
     ResponseUserDTO changeUserRole(@NonNull Long userId, @NonNull Role newRole);
+
+    /**
+     * Returns a paginated list of users for the admin dashboard.
+     * Supports optional search by user name or email.
+     *
+     * @param pageable pagination parameters
+     * @param search optional search query
+     * @return paginated list of users
+     */
+    @NonNull
+    Page<ResponseUserDTO> getUsers(@NonNull Pageable pageable, String search);
 }

--- a/src/main/java/com/itasocialacademy/oitassist/user/service/interfaces/UserService.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/service/interfaces/UserService.java
@@ -69,12 +69,13 @@ public interface UserService extends BaseService<Long, CreateUserDTO, UpdateUser
     ResponseUserDTO changeUserRole(@NonNull Long userId, @NonNull Role newRole);
 
     /**
-     * Returns a paginated list of users for the admin dashboard.
-     * Supports optional search by username or email.
+     * Returns a paginated list of users for the admin dashboard. Supports optional
+     * search by name or email.
      *
      * @param pageable pagination parameters
      * @param search   optional search query
      * @return paginated list of users
+     * @throws InsufficientPermissionsException if user does not have admin role
      */
     @NonNull
     Page<ResponseUserDTO> getUsers(@NonNull Pageable pageable, String search);

--- a/src/main/java/com/itasocialacademy/oitassist/user/service/interfaces/UserService.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/service/interfaces/UserService.java
@@ -70,10 +70,10 @@ public interface UserService extends BaseService<Long, CreateUserDTO, UpdateUser
 
     /**
      * Returns a paginated list of users for the admin dashboard.
-     * Supports optional search by user name or email.
+     * Supports optional search by username or email.
      *
      * @param pageable pagination parameters
-     * @param search optional search query
+     * @param search   optional search query
      * @return paginated list of users
      */
     @NonNull

--- a/src/test/java/com/itasocialacademy/oitassist/users/controller/UsersControllerTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/users/controller/UsersControllerTest.java
@@ -7,10 +7,15 @@ import com.itasocialacademy.oitassist.user.dao.dto.response.ResponseUserDTO;
 import com.itasocialacademy.oitassist.user.dao.enums.Role;
 import com.itasocialacademy.oitassist.user.dao.enums.UserStatus;
 import com.itasocialacademy.oitassist.user.service.interfaces.UserService;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 
 import static org.mockito.Mockito.*;
@@ -102,5 +107,70 @@ class UsersControllerTest extends ControllerUnitTest<UserController> {
             .andExpect(status().isBadRequest());
 
         verifyNoInteractions(userService);
+    }
+
+    @Test
+    @DisplayName("getUsers should return paged users when request is valid")
+    void getUsers_ShouldReturnPagedUsers_WhenRequestIsValid() throws Exception {
+        Pageable pageable = PageRequest.of(0, 10);
+
+        ResponseUserDTO user = ResponseUserDTO.builder()
+            .id(1L)
+            .email("ivan@example.com")
+            .firstName("Ivan")
+            .lastName("Petrenko")
+            .middleName("Ivanovych")
+            .role(Role.USER)
+            .status(UserStatus.ACTIVE)
+            .build();
+
+        Page<ResponseUserDTO> page = new PageImpl<>(List.of(user), pageable, 1);
+
+        when(userService.getUsers(any(Pageable.class), eq("ivan"))).thenReturn(page);
+
+        mockMvc.perform(get("/api/v1/users")
+            .param("page", "0")
+            .param("size", "10")
+            .param("search", "ivan"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content[0].id").value(1))
+            .andExpect(jsonPath("$.content[0].email").value("ivan@example.com"))
+            .andExpect(jsonPath("$.content[0].firstName").value("Ivan"))
+            .andExpect(jsonPath("$.content[0].lastName").value("Petrenko"))
+            .andExpect(jsonPath("$.content[0].middleName").value("Ivanovych"))
+            .andExpect(jsonPath("$.content[0].role").value("USER"))
+            .andExpect(jsonPath("$.content[0].status").value("ACTIVE"))
+            .andExpect(jsonPath("$.pageNumber").value(0))
+            .andExpect(jsonPath("$.pageSize").value(10))
+            .andExpect(jsonPath("$.totalPages").value(1))
+            .andExpect(jsonPath("$.totalElements").value(1))
+            .andExpect(jsonPath("$.first").value(true))
+            .andExpect(jsonPath("$.last").value(true));
+
+        verify(userService).getUsers(any(Pageable.class), eq("ivan"));
+    }
+
+    @Test
+    @DisplayName("getUsers should return paged users when search parameter is not provided")
+    void getUsers_ShouldReturnPagedUsers_WhenSearchParameterIsNotProvided() throws Exception {
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<ResponseUserDTO> emptyPage = Page.empty(pageable);
+
+        when(userService.getUsers(any(Pageable.class), isNull())).thenReturn(emptyPage);
+
+        mockMvc.perform(get("/api/v1/users")
+            .param("page", "0")
+            .param("size", "10"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content").isArray())
+            .andExpect(jsonPath("$.content").isEmpty())
+            .andExpect(jsonPath("$.pageNumber").value(0))
+            .andExpect(jsonPath("$.pageSize").value(10))
+            .andExpect(jsonPath("$.totalPages").value(0))
+            .andExpect(jsonPath("$.totalElements").value(0))
+            .andExpect(jsonPath("$.first").value(true))
+            .andExpect(jsonPath("$.last").value(true));
+
+        verify(userService).getUsers(any(Pageable.class), isNull());
     }
 }

--- a/src/test/java/com/itasocialacademy/oitassist/users/service/UserServiceImplTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/users/service/UserServiceImplTest.java
@@ -328,8 +328,8 @@ class UserServiceImplTest {
     @DisplayName("getUsers should normalize search query before repository call when search contains extra spaces")
     void getUsers_ShouldNormalizeSearchQuery_WhenSearchContainsExtraSpaces() {
         Pageable pageable = PageRequest.of(0, 10);
-        String search = "  Ivan   Petrenko  ";
-        String normalizedSearch = "Ivan Petrenko";
+        String search = "  Ivan   Petrenko%  ";
+        String normalizedSearch = "Ivan Petrenko\\%";
 
         Page<User> emptyPage = Page.empty(pageable);
 
@@ -347,13 +347,13 @@ class UserServiceImplTest {
     }
 
     @Test
-    @DisplayName("getUsers should use empty search string when search is null")
+    @DisplayName("getUsers should use findAll when search is null")
     void getUsers_ShouldUseEmptySearchString_WhenSearchIsNull() {
         Pageable pageable = PageRequest.of(0, 10);
         Page<User> emptyPage = Page.empty(pageable);
 
         when(securityFacade.hasRole(String.valueOf(Role.ADMIN))).thenReturn(true);
-        when(repository.findAllBySearch("", pageable)).thenReturn(emptyPage);
+        when(repository.findAll(pageable)).thenReturn(emptyPage);
 
         Page<ResponseUserDTO> result = userService.getUsers(pageable, null);
 
@@ -361,7 +361,7 @@ class UserServiceImplTest {
         assertThat(result.getContent()).isEmpty();
 
         verify(securityFacade).hasRole(String.valueOf(Role.ADMIN));
-        verify(repository).findAllBySearch("", pageable);
+        verify(repository).findAll(pageable);
         verifyNoInteractions(mapper);
     }
 }

--- a/src/test/java/com/itasocialacademy/oitassist/users/service/UserServiceImplTest.java
+++ b/src/test/java/com/itasocialacademy/oitassist/users/service/UserServiceImplTest.java
@@ -13,6 +13,7 @@ import com.itasocialacademy.oitassist.user.exceptions.UserNotFoundException;
 import com.itasocialacademy.oitassist.user.exceptions.UserRoleSelfChangeException;
 import com.itasocialacademy.oitassist.user.mapper.UserMapper;
 import com.itasocialacademy.oitassist.user.service.UserServiceImpl;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,6 +24,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
@@ -258,5 +263,105 @@ class UserServiceImplTest {
         verify(securityFacade).hasRole(String.valueOf(Role.ADMIN));
         verify(securityFacade).getCurrentUserId();
         verifyNoInteractions(repository, mapper);
+    }
+
+    @Test
+    @DisplayName("getUsers should return paged users when current user is admin")
+    void getUsers_ShouldReturnPagedUsers_WhenCurrentUserIsAdmin() {
+        Pageable pageable = PageRequest.of(0, 10);
+        String search = "ivan";
+
+        User user = User.builder()
+            .id(1L)
+            .email("ivan@example.com")
+            .firstName("Ivan")
+            .surname("Petrenko")
+            .middleName("Ivanovych")
+            .role(Role.USER)
+            .userStatus(UserStatus.ACTIVE)
+            .build();
+
+        ResponseUserDTO responseUserDTO = ResponseUserDTO.builder()
+            .id(1L)
+            .email("ivan@example.com")
+            .firstName("Ivan")
+            .lastName("Petrenko")
+            .middleName("Ivanovych")
+            .role(Role.USER)
+            .status(UserStatus.ACTIVE)
+            .build();
+
+        Page<User> userPage = new PageImpl<>(List.of(user), pageable, 1);
+
+        when(securityFacade.hasRole(String.valueOf(Role.ADMIN))).thenReturn(true);
+        when(repository.findAllBySearch("ivan", pageable)).thenReturn(userPage);
+        when(mapper.toResponseUserDTO(user)).thenReturn(responseUserDTO);
+
+        Page<ResponseUserDTO> result = userService.getUsers(pageable, search);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().getFirst().getId()).isEqualTo(1L);
+        assertThat(result.getContent().getFirst().getEmail()).isEqualTo("ivan@example.com");
+
+        verify(securityFacade).hasRole(String.valueOf(Role.ADMIN));
+        verify(repository).findAllBySearch("ivan", pageable);
+        verify(mapper).toResponseUserDTO(user);
+    }
+
+    @Test
+    @DisplayName("getUsers should throw InsufficientPermissionsException when current user is not admin")
+    void getUsers_ShouldThrowInsufficientPermissionsException_WhenCurrentUserIsNotAdmin() {
+        Pageable pageable = PageRequest.of(0, 10);
+
+        when(securityFacade.hasRole(String.valueOf(Role.ADMIN))).thenReturn(false);
+
+        assertThatThrownBy(() -> userService.getUsers(pageable, "ivan"))
+            .isInstanceOf(InsufficientPermissionsException.class)
+            .hasMessage("You do not have enough permissions to perform this action");
+
+        verify(securityFacade).hasRole(String.valueOf(Role.ADMIN));
+        verifyNoInteractions(repository, mapper);
+    }
+
+    @Test
+    @DisplayName("getUsers should normalize search query before repository call when search contains extra spaces")
+    void getUsers_ShouldNormalizeSearchQuery_WhenSearchContainsExtraSpaces() {
+        Pageable pageable = PageRequest.of(0, 10);
+        String search = "  Ivan   Petrenko  ";
+        String normalizedSearch = "Ivan Petrenko";
+
+        Page<User> emptyPage = Page.empty(pageable);
+
+        when(securityFacade.hasRole(String.valueOf(Role.ADMIN))).thenReturn(true);
+        when(repository.findAllBySearch(normalizedSearch, pageable)).thenReturn(emptyPage);
+
+        Page<ResponseUserDTO> result = userService.getUsers(pageable, search);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).isEmpty();
+
+        verify(securityFacade).hasRole(String.valueOf(Role.ADMIN));
+        verify(repository).findAllBySearch(normalizedSearch, pageable);
+        verifyNoInteractions(mapper);
+    }
+
+    @Test
+    @DisplayName("getUsers should use empty search string when search is null")
+    void getUsers_ShouldUseEmptySearchString_WhenSearchIsNull() {
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<User> emptyPage = Page.empty(pageable);
+
+        when(securityFacade.hasRole(String.valueOf(Role.ADMIN))).thenReturn(true);
+        when(repository.findAllBySearch("", pageable)).thenReturn(emptyPage);
+
+        Page<ResponseUserDTO> result = userService.getUsers(pageable, null);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).isEmpty();
+
+        verify(securityFacade).hasRole(String.valueOf(Role.ADMIN));
+        verify(repository).findAllBySearch("", pageable);
+        verifyNoInteractions(mapper);
     }
 }


### PR DESCRIPTION
# OitAssist PR
## Issue Link 📋
<a href="https://github.com/ita-social-projects/oitAssist/issues/327">#327</a>

## Changed
- Added admin-only API endpoint for fetching users with pagination and optional search
- Implemented service-layer access validation for user list retrieval
- Added paginated user search support in the repository layer
- Normalized search input before executing user lookup
- Returned paginated results via PageResponse<ResponseUserDTO>
- Added controller tests for user list endpoint
- Added service unit tests for user list retrieval logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin-only `GET /api/v1/users` endpoint with pagination.
  * Supports optional `search` filtering (by name/email) and returns paginated results with metadata.
* **Bug Fixes**
  * Improved search input handling by normalizing whitespace and safely processing special characters.
* **Documentation**
  * Updated API metadata for the users listing endpoint and returned fields.
* **Tests**
  * Added tests for paginated listing, searching (including empty results), and enforcing admin permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->