### PR TITLE
[Fix] Resending verification email when activation token has expired

### DIFF
--- a/src/main/java/com/itasocialacademy/oitassist/security/config/SecurityConfig.java
+++ b/src/main/java/com/itasocialacademy/oitassist/security/config/SecurityConfig.java
@@ -65,7 +65,8 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.POST,
                     "/api/v1/registration/**",
                     "/api/v1/security/signIn",
-                    "/api/v1/security/refresh")
+                    "/api/v1/security/refresh",
+                    "/api/v1/user-activation/resend")
                 .permitAll()
                 .requestMatchers(HttpMethod.GET,
                     "/api/v1/news/**",

--- a/src/main/java/com/itasocialacademy/oitassist/user/dao/model/UserActivationToken.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/dao/model/UserActivationToken.java
@@ -44,7 +44,7 @@ public class UserActivationToken {
     @Column(name = "last_sent_at", nullable = false)
     private Instant lastSentAt;
 
-    @Column(name = "expires_at", nullable = false, updatable = false)
+    @Column(name = "expires_at", nullable = false)
     private Instant expiresAt;
 
     public boolean isExpired() {
@@ -67,5 +67,12 @@ public class UserActivationToken {
         return UserActivationToken.builder().createdAt(now)
             .expiresAt(now.plus(15, ChronoUnit.MINUTES)).token(UUID.randomUUID().toString())
             .lastSentAt(now).build();
+    }
+
+    public void regenerate() {
+        Instant now = Instant.now();
+        this.token = UUID.randomUUID().toString();
+        this.expiresAt = now.plus(15, ChronoUnit.MINUTES);
+        this.lastSentAt = now;
     }
 }

--- a/src/main/java/com/itasocialacademy/oitassist/user/service/UserActivationServiceImpl.java
+++ b/src/main/java/com/itasocialacademy/oitassist/user/service/UserActivationServiceImpl.java
@@ -110,14 +110,20 @@ public class UserActivationServiceImpl implements UserActivationService {
     }
 
     /**
-     * Returns the current token if still valid, or generates a fresh one. Enforces
-     * a 2-minute resend cooldown when an unexpired token exists.
+     * Returns the current token if still valid, or regenerates the existing one if
+     * it has expired. Enforces a 2-minute resend cooldown when an unexpired token
+     * exists.
      */
     private UserActivationToken prepareActivationToken(User user) {
         UserActivationToken token = user.getUserActivationToken();
-        if (token == null || token.isExpired()) {
+        if (token == null) {
             token = UserActivationToken.generateActivationToken();
             user.setUserActivationToken(token);
+            return token;
+        }
+
+        if (token.isExpired()) {
+            token.regenerate();
             return token;
         }
 


### PR DESCRIPTION
# OitAssist PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now resend activation emails more reliably, with expired activation tokens being regenerated automatically.
  * Activation tokens can now be refreshed after creation, extending their validity when needed.

* **Bug Fixes**
  * Improved activation resend behavior so newly created tokens are handled correctly and existing valid tokens continue to respect the resend cooldown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->