### PR TITLE
[CHORE] standardize line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
-/mvnw text eol=lf
+* text=auto eol=lf
+
 *.cmd text eol=crlf
+*.bat text eol=crlf


### PR DESCRIPTION
# OitAssist PR
## Issue Link 📋
<a href="https://github.com/ita-social-projects/oitAssist/issues/340">#340</a>

The `.gitattributes` file has been updated to standardize line endings throughout the project.

## Changed
- Added `* text=auto eol=lf`: globally enforces the use of `LF` for all text files.
- Added/updated `*.cmd text eol=crlf` and `*.bat text eol=crlf`: preserves the `CRLF` format exclusively for Windows scripts to ensure they work in `cmd.exe`.

## Why This Is Important
This resolves the issue of “phantom” changes and conflicts during branch merges when developers on Windows and Linux/macOS accidentally commit different line endings (`\r\n` vs `\n`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized repository line endings to use LF by default for text files.
  * Ensured Windows command files continue to use CRLF line endings for better cross-platform consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->