### PR TITLE
[CI] run full Maven verify during CI build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,8 +24,8 @@ jobs:
           java-version: 25
           distribution: temurin
 
-      - name: Validate code style
-        run: mvn validate
+      - name: Verify project
+        run: mvn clean verify
 
           #- name: Run a multi-line script
           #  env:


### PR DESCRIPTION
Replace `mvn validate` with `mvn clean verify` in the CI workflow to ensure pull requests execute all project verification steps, including compilation, unit tests, and Spring Modulith architecture verification.

# OitAssist PR
## Issue Link 📋
<a href="https://github.com/ita-social-projects/oitAssist/issues/356">#356 </a>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated build verification process to perform a clean, complete project verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->