### PR TITLE
Fix: include missing Liquibase changeset for `users.middle_name` nullable constraint

### DIFF
--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -16,6 +16,7 @@
     <include file="/db/changelog/logs/2026-07-06-ch-update-enums-for-competitions-and-stages-Pampukha.xml"/>
     <include file="/db/changelog/logs/2026-07-08-ch-create-applications-Haleliuk.xml"/>
     <include file="/db/changelog/logs/2026-07-08-ch-create-participants-Haleliuk.xml"/>
+    <include file="/db/changelog/logs/2026-07-08-ch-alter-users-middle-name-Huz.xml"/>
     <include file="/db/changelog/logs/2026-07-10-ch-update-applications-Haleliuk.xml"/>
     <include file="/db/changelog/logs/2026-07-09-ch-add-ownerId-to-task-bodies-Selianyk.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
# OitAssist PR

## Problem
Google OAuth2 registration was failing with a NOT NULL constraint violation on
`users.middle_name`. The changeset to drop this constraint
(`alter-users-middle-name-nullable`) existed but was never wired into the master
changelog, so it never ran.

## Fix
Added the missing `<include file="..."/>` entry to the master changelog so the
changeset executes on next deploy/restart.

## Verification
- Confirmed changeset now appears in `databasechangelog` after restart.
- Confirmed `information_schema.columns` shows `is_nullable = YES` for `middle_name`.
- Re-ran Google OAuth2 login/registration flow — new user created successfully,
  no constraint violation.

Closes #367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a database migration to support changes to user middle-name data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->