### PR TITLE
[Feature] Implement task deletion

### DIFF
--- a/src/main/java/com/itasocialacademy/oitassist/task/controller/TaskController.java
+++ b/src/main/java/com/itasocialacademy/oitassist/task/controller/TaskController.java
@@ -143,7 +143,7 @@ public class TaskController {
             content = @Content(mediaType = "application/json",
                 schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @PatchMapping("/changeOwner/{taskId}")
+    @PatchMapping("/{taskId}/change-owner")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<TaskResponseDTO> changeOwner(@PathVariable Long taskId,
         @Valid @RequestBody ChangeOwnerRequestDTO changeOwnerRequest) {

--- a/src/main/java/com/itasocialacademy/oitassist/task/controller/TaskController.java
+++ b/src/main/java/com/itasocialacademy/oitassist/task/controller/TaskController.java
@@ -149,4 +149,11 @@ public class TaskController {
         @Valid @RequestBody ChangeOwnerRequestDTO changeOwnerRequest) {
         return ResponseEntity.ok().body(taskService.changeTaskOwner(taskId, changeOwnerRequest));
     }
+
+    @DeleteMapping("/{taskId}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'ORG')")
+    public ResponseEntity<Void> deleteTask(@PathVariable Long taskId) {
+        taskService.deleteTask(taskId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/itasocialacademy/oitassist/task/controller/TaskController.java
+++ b/src/main/java/com/itasocialacademy/oitassist/task/controller/TaskController.java
@@ -150,6 +150,18 @@ public class TaskController {
         return ResponseEntity.ok().body(taskService.changeTaskOwner(taskId, changeOwnerRequest));
     }
 
+    @Operation(
+        summary = "Delete a task",
+        description = "Deletes a task by its id. Only the task owner or users with ADMIN role can delete a task.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "204", description = "Task deleted successfully"),
+        @ApiResponse(responseCode = "403", description = "Access denied - User does not own this task",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "Task not found",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @DeleteMapping("/{taskId}")
     @PreAuthorize("hasAnyRole('ADMIN', 'ORG')")
     public ResponseEntity<Void> deleteTask(@PathVariable Long taskId) {

--- a/src/main/java/com/itasocialacademy/oitassist/task/service/TaskServiceImpl.java
+++ b/src/main/java/com/itasocialacademy/oitassist/task/service/TaskServiceImpl.java
@@ -175,9 +175,7 @@ public class TaskServiceImpl implements TaskService {
     }
 
     private void checkOwnerOrAdmin(Long taskBodyOwnerId, Long taskId) {
-        boolean isAdmin = securityFacade.hasRole("ADMIN");
-        boolean isOwner = securityFacade.isOwner(taskBodyOwnerId);
-        if (!isAdmin && !isOwner) {
+        if (!securityFacade.hasRole("ADMIN") && !securityFacade.isOwner(taskBodyOwnerId)) {
             throw new TaskAccessRestrictedException(taskId);
         }
     }

--- a/src/main/java/com/itasocialacademy/oitassist/task/service/TaskServiceImpl.java
+++ b/src/main/java/com/itasocialacademy/oitassist/task/service/TaskServiceImpl.java
@@ -141,7 +141,8 @@ public class TaskServiceImpl implements TaskService {
         return taskBodyMapper.toResponse(taskBodyRepository.save(task));
     }
 
-    // TODO: Implement TaskAssignment validation to check if this task is currently assigned to any tour.
+    // TODO: Implement TaskAssignment validation to check if this task is currently
+    // assigned to any tour.
     @Override
     @Transactional
     public void deleteTask(Long taskId) {

--- a/src/main/java/com/itasocialacademy/oitassist/task/service/TaskServiceImpl.java
+++ b/src/main/java/com/itasocialacademy/oitassist/task/service/TaskServiceImpl.java
@@ -96,9 +96,7 @@ public class TaskServiceImpl implements TaskService {
         TaskBody existingTask = taskBodyRepository.findById(taskId)
             .orElseThrow(() -> new TaskNotFoundException(taskId));
 
-        if (!isOwnerOrAdmin(existingTask.getOwnerId())) {
-            throw new TaskAccessRestrictedException(taskId);
-        }
+        checkOwnerOrAdmin(existingTask.getOwnerId(), existingTask.getId());
 
         existingTask.setTitle(requestDTO.title());
         existingTask.setDescription(requestDTO.description());
@@ -150,9 +148,7 @@ public class TaskServiceImpl implements TaskService {
         TaskBody taskToDelete = taskBodyRepository.findById(taskId)
             .orElseThrow(() -> new TaskNotFoundException(taskId));
 
-        if (!isOwnerOrAdmin(taskToDelete.getOwnerId())) {
-            throw new TaskAccessRestrictedException(taskId);
-        }
+        checkOwnerOrAdmin(taskToDelete.getOwnerId(), taskToDelete.getId());
 
         taskBodyRepository.delete(taskToDelete);
         log.debug("Task {} with title {} deleted", taskId, taskToDelete.getTitle());
@@ -177,11 +173,12 @@ public class TaskServiceImpl implements TaskService {
             new FilesDetachRequestedEvent(RelatedEntityType.TASK, taskBodyId, removedFileIds, authorId));
     }
 
-    private boolean isOwnerOrAdmin(Long taskBodyOwnerId) {
-        if (securityFacade.hasRole("ADMIN")) {
-            return true;
+    private void checkOwnerOrAdmin(Long taskBodyOwnerId, Long taskId) {
+        boolean isAdmin = securityFacade.hasRole("ADMIN");
+        boolean isOwner = securityFacade.isOwner(taskBodyOwnerId);
+        if (!isAdmin && !isOwner) {
+            throw new TaskAccessRestrictedException(taskId);
         }
-        return securityFacade.isOwner(taskBodyOwnerId);
     }
 
     private boolean isOrgOrAdmin(UserAuthDetails userDetails) {

--- a/src/main/java/com/itasocialacademy/oitassist/task/service/TaskServiceImpl.java
+++ b/src/main/java/com/itasocialacademy/oitassist/task/service/TaskServiceImpl.java
@@ -143,6 +143,21 @@ public class TaskServiceImpl implements TaskService {
         return taskBodyMapper.toResponse(taskBodyRepository.save(task));
     }
 
+    // TODO: Implement TaskAssignment validation to check if this task is currently assigned to any tour.
+    @Override
+    @Transactional
+    public void deleteTask(Long taskId) {
+        TaskBody taskToDelete = taskBodyRepository.findById(taskId)
+            .orElseThrow(() -> new TaskNotFoundException(taskId));
+
+        if (!isOwnerOrAdmin(taskToDelete.getOwnerId())) {
+            throw new TaskAccessRestrictedException(taskId);
+        }
+
+        taskBodyRepository.delete(taskToDelete);
+        log.debug("Task {} with title {} deleted", taskId, taskToDelete.getTitle());
+    }
+
     // helpers
     private void publishAttachEvent(Long taskBodyId, List<Long> fileIds, Long authorId) {
         if (fileIds == null || fileIds.isEmpty()) {

--- a/src/main/java/com/itasocialacademy/oitassist/task/service/interfaces/TaskService.java
+++ b/src/main/java/com/itasocialacademy/oitassist/task/service/interfaces/TaskService.java
@@ -77,4 +77,6 @@ public interface TaskService {
      *                               role
      */
     TaskResponseDTO changeTaskOwner(Long taskId, ChangeOwnerRequestDTO changeOwnerRequest);
+
+    void deleteTask(Long taskId);
 }

--- a/src/main/java/com/itasocialacademy/oitassist/task/service/interfaces/TaskService.java
+++ b/src/main/java/com/itasocialacademy/oitassist/task/service/interfaces/TaskService.java
@@ -78,5 +78,14 @@ public interface TaskService {
      */
     TaskResponseDTO changeTaskOwner(Long taskId, ChangeOwnerRequestDTO changeOwnerRequest);
 
+    /**
+     * Deletes a task by its id. Only the task owner or users with ADMIN role can
+     * delete a task.
+     *
+     * @param taskId the ID of the task to delete
+     * @throws TaskNotFoundException         if the task does not exist
+     * @throws TaskAccessRestrictedException if the user is neither the task owner
+     *                                       nor an ADMIN
+     */
     void deleteTask(Long taskId);
 }


### PR DESCRIPTION
# OitAssist PR
## Issue Link 📋
<a href="https://github.com/ita-social-projects/oitAssist/issues/366">#366</a>

## Changed
- Create endpoint for task deletion
- Add deletion logic to TaskServiceImpl
- Refactor the URL for changeOwner endpoint in TaskController
- Refactor the isOwnerOrAdmin method
- Add JavaDoc for deletion method in TaskService
- Add OpenApi docs to delete endpoint in TaskController

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to delete tasks.
  - Task deletion is restricted to task owners and administrators.
  - Successful deletion returns a “No Content” response.

- **Improvements**
  - Updated the task-owner change endpoint to use the `/change-owner` URL format.
  - Standardized authorization checks for task updates and deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->